### PR TITLE
Add base terraform code

### DIFF
--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,14 @@
+terraform-automation-key.json
+battlecode22-deploy-key.json
+# secret files are in json format, conservatively ignore all of jsons to prevent accidental pushes
+*.json 
+
+# Terraform files
+.terraform
+# note: .terraform.lock.hcl should be committed. not ignored.
+# we ignore tfstate because we don't want someone accidentally committing it. we want to use gcs state
+*.tfstate.*
+
+*.tfvars
+# gitignore the secret twice for good measure
+secret.tfvars

--- a/deploy/.terraform.lock.hcl
+++ b/deploy/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.31.0"
+  hashes = [
+    "h1:DA4SJl2ZCC5R7z7pEvY9OZPnFzXOJtMEhCGL4dZiegs=",
+    "zh:02a19ed46c2007f6aadfb6ff90aa6063be063194d1f0dd02dc839adc212f7cae",
+    "zh:1046de7e13e81a8f86461f99e9d5ff25d5dabe8465f51efe72084ded426ba771",
+    "zh:209b054685f7364f3f5e8b570ceb62701e5b466d37cce8b7108385fc1feb3683",
+    "zh:717773619a1102748204699974c30aba39dc727baf389b874afcab6e17b63ffa",
+    "zh:7d5f4885cda2ca0ec8cb8bac36ea156aeca7787c01c17e65f7226742b60369d8",
+    "zh:82df57f2df5708441c57045b3e1a9a91ed55abe67d0d2f00705c7a1f512ec6ec",
+    "zh:a0191b194e68dd3c0ac5a26712f95d435839ff20d2b2ad53670374c64946042d",
+    "zh:a95b8358469d6347a5bcf4462ad18efaf80014f07f36bd26019ca039c523ff48",
+    "zh:b62c968f50d3afa8300c9267388d273a90a5be1a4e9a218205a358e6954e7844",
+    "zh:bc11cc9b8defec24831bbd6a73a2fa940659c7c610ea7aa0d8b38c2b1af6689b",
+    "zh:e6ac4c46c3e5a32635fcd27784c189b6cbc6aa9cbf7a3b09e999ec3aa3e2004a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,95 @@
+# infra
+
+terraform configs!
+
+## one-time setup for Google Cloud Project
+
+These need only be done once per project. (We've already done these on the `mitbattlecode` project, here: https://console.cloud.google.com/home/dashboard?project=mitbattlecode. These instructions are here just for posterity)
+
+create an iam worker for terraform, and give it some necessary permissions. See https://console.cloud.google.com/iam-admin/iam?referrer=search&project=mitbattlecode for an example.
+
+if the bucket referenced in `state.tf` doesn't exist in the Google Cloud project yet, you should create it, on the Google Cloud website interface. Go to `Cloud Storage`, which lists frontend buckets, and press `create bucket`, which should take you here: https://console.cloud.google.com/storage/create-bucket?project=mitbattlecode
+
+## one-time setup for your personal machine
+
+These steps need to be run only once for each local machine / installation.
+
+**if your machine doesn't have a `terraform-automation-key.json` file:** from the directory that this README is in (that same level!), generate a service account key, necessary for terraform to work:
+
+```
+gcloud iam service-accounts keys create terraform-automation-key.json --iam-account=terraform@mitbattlecode.iam.gserviceaccount.com
+```
+
+**if you have not run this step on your machine yet**, configure docker to push to our container registry:
+
+```
+gcloud auth configure-docker us-east1-docker.pkg.dev
+```
+
+**ask devs for any further configuration steps, eg via Slack or Notion**
+
+finally, **if not done on your machine yet, initialize terraform!**
+
+```
+terraform init
+```
+
+## deployment
+
+**NOTE: these notes are old. Don't follow them blindly; instead, adjust every step to fit the new repo and setup. When a section is up-to-date, remove the "OLD" note from each section**
+
+### deploying saturn workers
+
+**OLD DO NOT USE**
+
+build & push images:
+
+```
+cd ../worker && make push && cd ../infra
+```
+
+then, update `variables.tf` with the new sha256 hashes of the pushed images. these hashes are at the bottom of `make push`'s output, here:
+![image](https://user-images.githubusercontent.com/14008996/147513611-59030a82-e771-4d75-b904-fbe841910778.png)
+
+you may now run
+
+```
+terraform apply -var-file="secret.tfvars"
+```
+
+verify that the deployment is what you expect it to be! and then answer `yes` when it prompts you
+
+next, do a rolling **replace** of the **execute** images. this ought to be unnecessary, but terraform is weird. anyways
+
+finally, commit and push your changes (to all `.tf` files and the `.terraform.lock.hcl` if applicable)
+
+### releasing bc22
+
+**OLD DO NOT USE**
+
+in `distribution22.tf`, simply uncomment the `member = "allUsers"` line. that should be enough!
+
+after doing that, run
+
+```
+terraform apply -var-file="secret.tfvars"
+```
+
+verify that the deployment is what you expect it to be! and then answer `yes` when it prompts you
+
+finally, commit and push your changes (to all `.tf` files and the `.terraform.lock.hcl` if applicable)
+
+### other deploys
+
+**OLD DO NOT USE**
+
+first do any changes you want to do in the `.tf` files.
+when you have done that and everything else to prepare for deploy, run
+
+```
+terraform apply -var-file="secret.tfvars"
+```
+
+verify that the deployment is what you expect it to be! and then answer `yes` when it prompts you
+
+finally, commit and push your changes (to all `.tf` files and the `.terraform.lock.hcl` if applicable)

--- a/deploy/state.tf
+++ b/deploy/state.tf
@@ -1,0 +1,17 @@
+# this is for managing terraform state, which we store in the following bucket
+# Note: if you're making a new project, you (probably) have to create this bucket first manually, 
+# before the rest of Terraform can work.
+
+# Create a GCS Bucket
+resource "google_storage_bucket" "tf-bucket" {
+  provider = google
+
+  project       = var.gcp_project
+  name          = "terraform-state-mitbattlecode"
+  location      = var.gcp_region
+  force_destroy = true
+  storage_class = "REGIONAL"
+  versioning {
+    enabled = true
+  }
+}


### PR DESCRIPTION
initialize terraform for the _entire_ project, and add the files and (revised) README instructions too.

This PR is general for the entire codebase: for now, there's nothing specific to the frontend, or backend, etc.
(The "Deployment" instructions are specific and definitely need revising; this has been made clear in the readme)