### PR TITLE
Rename a method and comments, for clarity

### DIFF
--- a/frontend/src/sidebar.js
+++ b/frontend/src/sidebar.js
@@ -66,7 +66,7 @@ class SideBar extends Component {
 
   // Note that this duplicates a method in submissions.js;
   // this will be cleaned up. See #74
-  isSubmissionEnabled() {
+  isGameReleasedForUser() {
     if (this.state.user.is_staff == true) {
       return true;
     }
@@ -126,8 +126,9 @@ class SideBar extends Component {
               <NLink to={`/team`} icon={"pe-7s-users"} label="Team" />
             )}
 
-            {/* Only visible when on a team AND submissions are enabled */}
-            {this.state.on_team && this.isSubmissionEnabled() && (
+            {/* #74 considers combining these two checks and &&, into one*/}
+            {/* Only visible when on a team AND game is released */}
+            {this.state.on_team && this.isGameReleasedForUser() && (
               <NLink
                 to={`/submissions`}
                 icon={"pe-7s-up-arrow "}
@@ -135,12 +136,12 @@ class SideBar extends Component {
               />
             )}
 
-            {/* Only visible when on a team AND submissions are enabled
+            {/* Only visible when on a team AND game is released
             Tried to de-dupe, but expressions must return only one JSX element,
             and I couldn't get both NLinks to be in the same element while still looking ok
             Do at your own risk
             - Nathan */}
-            {this.state.on_team && this.isSubmissionEnabled() && (
+            {this.state.on_team && this.isGameReleasedForUser() && (
               <NLink
                 to={`/scrimmaging`}
                 icon={"pe-7s-joy "}


### PR DESCRIPTION
Merging this one commit now, since it's been dangling for too long and causing disorganization.
The stuff that was gonna go in this PR can actually wait for a future PR anyways.

This method probably won't even stay around, after adjusting to new backend...
But the better name (even for a temporary method) can't hurt.

~for some set of issues, scope TBD...
At this point, holding off on this til backend API is sorta ready~