### PR TITLE
Remove the episode-only route, allowing for other non-episode routes

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -52,7 +52,6 @@ class App extends Component {
         {<Redirect to={`${MultiEpisode.getDefaultEpisode()}/home`} />}
       </Route>,
 
-      <Route exact path={`/:episode`} component={Home} key="home-blank" />,
       <Route path={`/:episode/home`} component={Home} key="home" />,
       <Route path={`/:episode/updates`} component={Updates} key="updates" />,
       // commented but kept since we might use this later


### PR DESCRIPTION
previously, /:episode would link to its own episode's home page. However, this makes routes such as /login fail. (This is because /login matches /:episode _first_, setting ":episode" to "login", and failing.)

I'm sure there's a solution to make the episode-only route work properly. IDK it yet tho, and right now this creates massive bugs.