### PR TITLE
Properly check is_staff, in case parent object wasn't set yet

### DIFF
--- a/frontend/src/components/userCard.js
+++ b/frontend/src/components/userCard.js
@@ -4,12 +4,15 @@ import Avatar from "../components/avatar";
 class UserCard extends Component {
   render() {
     const user_profile = this.props.user_profile;
-    const staff_msg = this.props.user_profile.user.is_staff ? (
-      <small>
-        {" "}
-        | <label>Staff</label>
-      </small>
-    ) : null;
+    const staff_msg =
+      // Short-circuit check for nested object,
+      // in case user_profile hasn't been set yet.
+      this.props.user_profile && this.state.user_profile.user.is_staff ? (
+        <small>
+          {" "}
+          | <label>Staff</label>
+        </small>
+      ) : null;
     return (
       <div className="card card-user">
         <div className="image"></div>

--- a/frontend/src/sidebar.js
+++ b/frontend/src/sidebar.js
@@ -74,7 +74,12 @@ class SideBar extends Component {
   // Note that this duplicates a method in submissions.js;
   // this will be cleaned up. See #74
   isGameReleasedForUser() {
-    if (this.state.user_profile.user.is_staff == true) {
+    if (
+      // Short-circuit check for nested object,
+      // in case user_profile hasn't been set yet.
+      this.state.user_profile &&
+      this.state.user_profile.user.is_staff == true
+    ) {
       return true;
     }
     if (this.state.league.game_released == true) {
@@ -179,13 +184,16 @@ class SideBar extends Component {
             <br />
 
             {/* Only visible if a staff user */}
-            {this.state.user_profile.user.is_staff && (
-              <NLink
-                to={`/${this.state.episode}/staff`}
-                icon={"pe-7s-tools"}
-                label="Staff"
-              />
-            )}
+            {this.state.user_profile &&
+              // Short-circuit check for nested object,
+              // in case user_profile hasn't been set yet.
+              this.state.user_profile.user.is_staff && (
+                <NLink
+                  to={`/${this.state.episode}/staff`}
+                  icon={"pe-7s-tools"}
+                  label="Staff"
+                />
+              )}
 
             <br />
           </ul>

--- a/frontend/src/views/submissions.js
+++ b/frontend/src/views/submissions.js
@@ -229,7 +229,12 @@ class Submissions extends Component {
   // Note that this duplicates a method in submissions.js;
   // this will be cleaned up. See #74
   isSubmissionEnabled() {
-    if (this.state.user_profile.user.is_staff == true) {
+    if (
+      // Short-circuit check for nested object,
+      // in case user_profile hasn't been set yet.
+      this.state.user_profile &&
+      this.state.user_profile.user.is_staff == true
+    ) {
       return true;
     }
     if (


### PR DESCRIPTION
Hotfix for #200 -- if the parent object wasn't set, we would try to get properties of undefined. Fixed here.

A more robust fix is to include `is_staff` within the root component; waiting for #193  to even bother with this