### PR TITLE
If trying to view pages needing authentication, don't redirect to 404 Not Found, before the auth can load

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -44,10 +44,6 @@ class App extends Component {
     // Does _NOT_ actually render a clickable link to that route.
     // That is done in navbar.js, sidebar.js, footer.js, etc
 
-    // NOTE: Every page in the following lists
-    // should render with navbar and sidebar, and should have an inherent episode.
-    // Handling otherwise is incredibly tricky, and is not worth the special case.
-
     // should always be viewable, even when not logged in
     this.nonLoggedInElems = [
       // Redirect empty path to the default episode's home page
@@ -128,12 +124,11 @@ class App extends Component {
     // When in the list of routes, this route must be last.
     // (for wildcard to work properly)
     this.notFoundElems = [
-      <Route path="*" key="notfound">
-        {/* Simply adding the NotFound component to the route will still have a sidebar, etc,
-        which is odd since the sidebar needs an episode but the not-found page doesn't necessarily have one
-        So, instead, redirect to a dedicated not-found route with just its own component */}
-        {<Redirect to={`/not-found`} />}
-      </Route>,
+      // Once upon a time, this redirected. This turned out not to work.
+      // For example, what happens if the requested route seems inaccessible now,
+      // just because login-check hasn't finished running?
+      // We need to make sure that login-check, etc, properly run first.
+      <Route path="*" component={NotFound} key="notfound" />,
     ];
 
     // Sets the login header based on currently held cookies, before any
@@ -159,6 +154,11 @@ class App extends Component {
   }
 
   render() {
+    // Note that the "toRender" arrays are computed during the render method
+    // This is important! Checking whether the user is logged-in, etc,
+    // takes an API call, which takes time.
+    // Whenever this API call finishes, we should always be ready to re-include the routes,
+    // and thus potentially re-render the URL that the user is looking to navigate to.
     let loggedInElemsToRender = this.state.logged_in ? this.loggedInElems : [];
     let onTeamElemsToRender = this.state.on_team ? this.onTeamElems : [];
     let staffElemsToRender =

--- a/frontend/src/navbar.js
+++ b/frontend/src/navbar.js
@@ -52,7 +52,7 @@ class NavBarAccount extends Component {
     // This is odd, see #93 for explanation
     this.state = {
       logged_in: null,
-      episode: MultiEpisode.getEpisodeFromCurrentPathname(),
+      episode: MultiEpisode.getEpisodeFromCurrentPathname(false),
     };
   }
   componentDidMount() {

--- a/frontend/src/sidebar.js
+++ b/frontend/src/sidebar.js
@@ -33,7 +33,7 @@ class SideBar extends Component {
       logged_in: null,
       user: {},
       league: {},
-      episode: MultiEpisode.getEpisodeFromCurrentPathname(),
+      episode: MultiEpisode.getEpisodeFromCurrentPathname(false),
     };
   }
 

--- a/frontend/src/views/multi-episode.jsx
+++ b/frontend/src/views/multi-episode.jsx
@@ -24,7 +24,7 @@ class MultiEpisode extends Component {
   // but we can't use it within the helper method)
   // NOTE: Assumes that when episodes are in URLs, the episode is the first part of the URL.
   // This is what we have done elsewhere, but is subject to change and this code would suddenly break.
-  static getEpisodeFromPathname(pathname) {
+  static getEpisodeFromPathname(pathname, forceRedirect = true) {
     // Special case:
     if (pathname == "" || pathname == "/") {
       return DEFAULT_EPISODE;
@@ -39,13 +39,17 @@ class MultiEpisode extends Component {
     if (EPISODES.includes(episodeInPathName)) {
       return episodeInPathName;
     } else {
-      window.location.replace("/not-found");
+      if (forceRedirect) {
+        window.location.replace("/not-found");
+      } else {
+        return null;
+      }
     }
   }
 
   // Gets the episode based on the currently navigated URL.
-  static getEpisodeFromCurrentPathname() {
-    return this.getEpisodeFromPathname(window.location.pathname);
+  static getEpisodeFromCurrentPathname(forceRedirect = true) {
+    return this.getEpisodeFromPathname(window.location.pathname, forceRedirect);
   }
 
   static getExtension(episode) {


### PR DESCRIPTION
Fixes, eg, going on a fresh tab to the account page. While you theoretically should be logged in, the website redirects you a 404 before it has a chance to validate your login.