### PR TITLE
Fix some warnings about user edit

### DIFF
--- a/frontend/src/views/account.js
+++ b/frontend/src/views/account.js
@@ -14,6 +14,8 @@ class Account extends Component {
           id: "",
           username: "",
           email: "",
+          first_name: "",
+          last_name: "",
         },
         gender: "",
         gender_details: "",


### PR DESCRIPTION
React told us this in console: bascially, if timing isn't quite right, name fields might not get picked up by change handler