### PR TITLE
Permission checks for first release (before submissions/scrim)

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -251,13 +251,13 @@ class App extends Component {
     // and thus potentially re-render the URL that the user is looking to navigate to.
 
     let loggedInElemsToRender = this.state.logged_in ? this.loggedInElems : [];
-    let onTeamElemsToRender =
-      on_team && is_game_released ? this.onTeamElems : [];
+    let onTeamAndGameReleasedElemsToRender =
+      on_team && is_game_released ? this.onTeamAndGameReleasedElems : [];
     let staffElemsToRender = is_staff ? this.staffElems : [];
 
     let elemsToRender = this.nonLoggedInElems.concat(
       loggedInElemsToRender,
-      onTeamElemsToRender,
+      onTeamAndGameReleasedElemsToRender,
       staffElemsToRender,
       // notFoundElems must be last to work properly
       this.notFoundElems


### PR DESCRIPTION
To make sure that the frontend doesn't expose too much. Backend perm checks are necessary anyways, but it helps to make sure frontend is alright.

Fixes #13, #69 (by virtue of the page not working and by the backend giving bad responses anyways if someone tries to hit the API directly)

What do we need to test?

If not logged in:
- [x] team/account page should not be navigable thru sidebar/navbar
- [x] team/account page should not be navigable thru going directly to the URL

If not on a team, even tho the episode is released and you are staff:
- [x] submission/scrimmaging pages should not be navigable thru sidebar/navbar
- [x] submission/scrimmaging page should not be navigable thru going directly to the URL

If **episode is not released and you are not staff**, even though you are on a team for it,
- [x] submission/scrimmaging pages should not be navigable thru sidebar/navbar
- [x] submission/scrimmaging page should not be navigable thru going directly to the URL

If you are on a team, the episode is released, and you are a normal user (or staff anyways): (careful to only test this locally)
- [x] submission/scrimmaging pages should be navigable thru sidebar/navbar
- [x] submission/scrimmaging page should be navigable thru going directly to the URL
(It's okay if these pages are broken for now; as long as they're visible...)