### PR TITLE
Make naming scheme consistent

### DIFF
--- a/backend/siarnaq/settings.py
+++ b/backend/siarnaq/settings.py
@@ -227,8 +227,8 @@ class Staging(Base):
 
     GALAXY_ADMIN_EMAILS = [
         "staging-siarnaq-agent@mitbattlecode.iam.gserviceaccount.com",
-        "saturn-staging-compile@mitbattlecode.iam.gserviceaccount.com",
-        "saturn-staging-execute@mitbattlecode.iam.gserviceaccount.com",
+        "staging-saturn-compile@mitbattlecode.iam.gserviceaccount.com",
+        "staging-saturn-execute@mitbattlecode.iam.gserviceaccount.com",
     ]
     GALAXY_ADMIN_USERNAME = "galaxy-admin"
 
@@ -287,8 +287,8 @@ class Production(Base):
 
     GALAXY_ADMIN_EMAILS = [
         "production-siarnaq-agent@mitbattlecode.iam.gserviceaccount.com",
-        "saturn-production-compile@mitbattlecode.iam.gserviceaccount.com",
-        "saturn-production-execute@mitbattlecode.iam.gserviceaccount.com",
+        "production-saturn-compile@mitbattlecode.iam.gserviceaccount.com",
+        "production-saturn-execute@mitbattlecode.iam.gserviceaccount.com",
     ]
     GALAXY_ADMIN_USERNAME = "galaxy-admin"
 

--- a/deploy/galaxy/main.tf
+++ b/deploy/galaxy/main.tf
@@ -81,7 +81,7 @@ module "titan" {
 module "saturn_compile" {
   source = "../saturn"
 
-  name        = "saturn-${var.name}-compile"
+  name        = "${var.name}-saturn-compile"
   gcp_project = var.gcp_project
   gcp_region  = var.gcp_region
   gcp_zone    = var.gcp_zone
@@ -105,7 +105,7 @@ module "saturn_compile" {
 module "saturn_execute" {
   source = "../saturn"
 
-  name        = "saturn-${var.name}-execute"
+  name        = "${var.name}-saturn-execute"
   gcp_project = var.gcp_project
   gcp_region  = var.gcp_region
   gcp_zone    = var.gcp_zone


### PR DESCRIPTION
Slightly frustrating that `staging-` and `production-` is always a prefix, except for Saturn. This is fixed here.