### PR TITLE
Remove mamba and fix bad trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,9 @@ on:
       - main
   pull_request:
     types:
-      - review_requested
-  workflow_dispatch: {}
+      - opened
+      - synchronize
+      - reopened
 
 defaults:
   run:
@@ -35,7 +36,6 @@ jobs:
         with:
           environment-file: environment-dev.yml
           use-only-tar-bz2: true
-          mamba-version: "*"
       - name: Run linter
         run: |
           pre-commit install
@@ -59,7 +59,6 @@ jobs:
         with:
           environment-file: environment-dev.yml
           use-only-tar-bz2: true
-          mamba-version: "*"
       - name: Initialize migrations
         run: ./manage.py makemigrations
         working-directory: ./backend


### PR DESCRIPTION
Closes #275. Documentation said that mamba could be faster than conda so we tried to use it. After looking at many CI runs in practice… perhaps it's faster, but the additional step of installing mamba was a lot slower, so let's drop it.