### PR TITLE
Add structured logging

### DIFF
--- a/backend/environment.yml
+++ b/backend/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - pip:
     - django-anymail==8.6
     - django-configurations==2.4
+    - django-structlog==4.0.1
     - django_rest_passwordreset==1.3.0
     - djangorestframework-simplejwt==5.2.2
     - google-cloud-scheduler==2.7.3

--- a/backend/siarnaq/api/compete/admin.py
+++ b/backend/siarnaq/api/compete/admin.py
@@ -1,3 +1,4 @@
+import structlog
 from django.contrib import admin
 
 from siarnaq.api.compete.models import (
@@ -8,14 +9,18 @@ from siarnaq.api.compete.models import (
 )
 from siarnaq.api.episodes.models import Map
 
+logger = structlog.get_logger(__name__)
+
 
 @admin.action(description="Add pending tasks to the Saturn queue")
 def enqueue(modeladmin, request, queryset):
+    logger.info("task_requeue", message="Re-queueing tasks to Saturn.")
     queryset.enqueue()
 
 
 @admin.action(description="Forcibly re-queue tasks to Saturn")
 def force_requeue(modeladmin, request, queryset):
+    logger.info("task_force_requeue", message="Forcibly re-queuing tasks to Saturn.")
     queryset.enqueue_all()
 
 

--- a/backend/siarnaq/api/teams/serializers.py
+++ b/backend/siarnaq/api/teams/serializers.py
@@ -134,6 +134,9 @@ class TeamCreateSerializer(TeamPrivateSerializer):
             )
         ]
 
+    def update(self, instance, validated_data):
+        raise NotImplementedError("Use UserPrivateSerializer to update users.")
+
 
 class TeamJoinSerializer(serializers.Serializer):
     join_key = serializers.CharField()

--- a/backend/siarnaq/api/teams/signals.py
+++ b/backend/siarnaq/api/teams/signals.py
@@ -1,3 +1,4 @@
+import structlog
 from django.conf import settings
 from django.db.models.signals import m2m_changed, post_save
 from django.dispatch import receiver
@@ -6,6 +7,8 @@ from rest_framework.exceptions import ValidationError
 from siarnaq.api.compete.models import MatchParticipant
 from siarnaq.api.teams.models import Team, TeamProfile, TeamStatus
 from siarnaq.api.user.models import User
+
+logger = structlog.get_logger(__name__)
 
 
 @receiver(post_save, sender=MatchParticipant)
@@ -17,6 +20,9 @@ def copy_rating_to_profile(instance, update_fields, **kwargs):
     if update_fields is not None and "rating" not in list(update_fields):
         return  # No new rating
     if instance.rating is not None:
+        logger.debug(
+            "team_rating", message="Team has new rating.", rating=instance.rating.value
+        )
         TeamProfile.objects.filter(
             team=instance.team_id, rating__n__lt=instance.rating.n
         ).update(rating=instance.rating)
@@ -26,6 +32,9 @@ def copy_rating_to_profile(instance, update_fields, **kwargs):
 def make_empty_team_inactive(instance, action, **kwargs):
     if action == "post_remove":
         if instance.members.count() == 0:
+            logger.debug(
+                "team_inactive", message="Team is now inactive.", team=instance.pk
+            )
             instance.status = TeamStatus.INACTIVE
             instance.save(update_fields=["status"])
 

--- a/backend/siarnaq/api/teams/views.py
+++ b/backend/siarnaq/api/teams/views.py
@@ -1,3 +1,4 @@
+import structlog
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
@@ -16,6 +17,8 @@ from siarnaq.api.teams.serializers import (
     TeamPrivateSerializer,
     TeamPublicSerializer,
 )
+
+logger = structlog.get_logger(__name__)
 
 
 class TeamViewSet(
@@ -96,6 +99,7 @@ class TeamViewSet(
         with transaction.atomic():
             team = get_object_or_404(self.get_queryset(), members=request.user)
             team.members.remove(request.user)
+        logger.debug("team_leave", message="User has left team.", team=team.pk)
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
     @extend_schema(responses={status.HTTP_204_NO_CONTENT: None})
@@ -120,4 +124,5 @@ class TeamViewSet(
                 episode=self.kwargs["episode_id"],
             )
             team.members.add(request.user)
+        logger.debug("team_join", message="User has joined team.", team=team.pk)
         return Response(None, status=status.HTTP_204_NO_CONTENT)

--- a/backend/siarnaq/api/user/signals.py
+++ b/backend/siarnaq/api/user/signals.py
@@ -1,10 +1,13 @@
 import urllib.parse
 
+import structlog
 from django.conf import settings
 from django.core.mail import send_mail
 from django.dispatch import receiver
 from django.template.loader import render_to_string
 from django_rest_passwordreset.signals import reset_password_token_created
+
+logger = structlog.get_logger(__name__)
 
 
 @receiver(reset_password_token_created)
@@ -17,8 +20,10 @@ def send_password_reset_token_email(
     """
 
     if not settings.EMAIL_ENABLED:
+        logger.warn("password_disabled", message="Password reset emails are disabled.")
         return
 
+    logger.info("password_email", message="Sending password reset email.")
     user_email = reset_password_token.user.email
     uri = f"{settings.FRONTEND_ORIGIN}/password_change/"
     token_encoded = urllib.parse.urlencode({"token": reset_password_token.key})

--- a/backend/siarnaq/gcloud/saturn.py
+++ b/backend/siarnaq/gcloud/saturn.py
@@ -1,7 +1,10 @@
 from concurrent.futures import Future
 
 import google.cloud.pubsub as pubsub
+import structlog
 from django.conf import settings
+
+logger = structlog.get_logger(__name__)
 
 
 class NullPublisher:
@@ -16,7 +19,9 @@ class NullPublisher:
 
 def get_publish_client() -> pubsub.PublisherClient | NullPublisher:
     if not settings.GCLOUD_ENABLE_ACTIONS:
+        logger.warn("saturn_disabled", message="Saturn queue is disabled.")
         return NullPublisher()
+
     return pubsub.PublisherClient(
         credentials=settings.GCLOUD_CREDENTIALS,
         publisher_options=pubsub.types.PublisherOptions(

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,6 +31,7 @@ dependencies:
   - pip:
     - django-anymail==8.6
     - django-configurations==2.4
+    - django-structlog==4.0.1
     - django_rest_passwordreset==1.3.0
     - djangorestframework-simplejwt==5.2.2
     - google-cloud-scheduler==2.7.3


### PR DESCRIPTION
Closes #178. Structured JSON logs are recognized and parsed by Google Cloud. As per documentation:

- "Exceptions contained in these logs are captured by and reported in Error Reporting." [[link](https://cloud.google.com/run/docs/logging)]
- "The `message` field of `jsonPayload`" is where you put the exception. "Log entries in Logging that contain stack traces or exceptions [...] generate errors in Error Reporting." [[link](https://cloud.google.com/error-reporting/docs/formatting-error-messages)]

This is implemented by `siarnaq.settings._gcloud_log_dumps`.

This PR also adds middleware that generates a log entry whenever a request throws an exception (ie. a 500).