### PR TITLE
Support deterministic ordering of maps in matches

### DIFF
--- a/backend/environment.yml
+++ b/backend/environment.yml
@@ -20,8 +20,9 @@ dependencies:
   - pip:
     - django-anymail==8.6
     - django-configurations==2.4
-    - django-structlog==4.0.1
     - django-countries==7.4.2
+    - django-sortedm2m==3.1.1
+    - django-structlog==4.0.1
     - django_rest_passwordreset==1.3.0
     - djangorestframework-simplejwt==5.2.2
     - google-cloud-scheduler==2.7.3

--- a/backend/siarnaq/api/compete/admin.py
+++ b/backend/siarnaq/api/compete/admin.py
@@ -111,7 +111,6 @@ class MatchAdmin(admin.ModelAdmin):
             },
         ),
     )
-    filter_horizontal = ("maps",)
     inlines = [MatchParticipantInline]
     list_display = (
         "__str__",
@@ -161,7 +160,6 @@ class ScrimmageRequestAdmin(admin.ModelAdmin):
         "is_ranked",
         "maps",
     )
-    filter_horizontal = ("maps",)
     list_display = (
         "pk",
         "requested_by",

--- a/backend/siarnaq/api/compete/models.py
+++ b/backend/siarnaq/api/compete/models.py
@@ -7,6 +7,7 @@ import structlog
 from django.apps import apps
 from django.conf import settings
 from django.db import models
+from sortedm2m.fields import SortedManyToManyField
 
 import siarnaq.api.refs as refs
 from siarnaq.api.compete.managers import (
@@ -175,7 +176,7 @@ class Match(SaturnInvocation):
     )
     """The tournament round to which this match belongs, if any."""
 
-    maps = models.ManyToManyField(refs.MAP_MODEL, related_name="matches")
+    maps = SortedManyToManyField(refs.MAP_MODEL, related_name="matches")
     """The maps to be played in this match."""
 
     alternate_order = models.BooleanField()
@@ -492,7 +493,7 @@ class ScrimmageRequest(models.Model):
     player_order = models.CharField(max_length=1, choices=PlayerOrder.choices)
     """The order of the players in the match."""
 
-    maps = models.ManyToManyField(refs.MAP_MODEL, related_name="scrimmage_requests")
+    maps = SortedManyToManyField(refs.MAP_MODEL, related_name="scrimmage_requests")
     """The maps to be played on the requested match."""
 
     objects = ScrimmageRequestQuerySet.as_manager()

--- a/backend/siarnaq/api/episodes/admin.py
+++ b/backend/siarnaq/api/episodes/admin.py
@@ -172,7 +172,6 @@ class TournamentRoundAdmin(admin.ModelAdmin):
         "release_status",
         "maps",
     )
-    filter_horizontal = ("maps",)
     inlines = [MatchInline]
     list_display = ("name", "tournament", "release_status")
     list_filter = ("tournament", "release_status")

--- a/backend/siarnaq/api/episodes/models.py
+++ b/backend/siarnaq/api/episodes/models.py
@@ -2,6 +2,7 @@ import structlog
 from django.apps import apps
 from django.db import models
 from django.utils import timezone
+from sortedm2m.fields import SortedManyToManyField
 
 from siarnaq.api.episodes.managers import EpisodeQuerySet, TournamentQuerySet
 
@@ -299,7 +300,7 @@ class TournamentRound(models.Model):
     name = models.CharField(max_length=64)
     """The name of this round in human-readable form, such as "Round 1"."""
 
-    maps = models.ManyToManyField(Map, related_name="tournament_rounds", blank=True)
+    maps = SortedManyToManyField(Map, related_name="tournament_rounds", blank=True)
     """The maps to be used in this round."""
 
     release_status = models.IntegerField(

--- a/backend/siarnaq/settings.py
+++ b/backend/siarnaq/settings.py
@@ -101,6 +101,7 @@ class Base(Configuration):
         "drf_spectacular",
         "django_rest_passwordreset",
         "anymail",
+        "sortedm2m",
         "siarnaq.api.user",
         "siarnaq.api.compete",
         "siarnaq.api.episodes",

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,8 +31,9 @@ dependencies:
   - pip:
     - django-anymail==8.6
     - django-configurations==2.4
-    - django-structlog==4.0.1
     - django-countries==7.4.2
+    - django-sortedm2m==3.1.1
+    - django-structlog==4.0.1
     - django_rest_passwordreset==1.3.0
     - djangorestframework-simplejwt==5.2.2
     - google-cloud-scheduler==2.7.3


### PR DESCRIPTION
Closes #292. Use [sortedm2m](https://github.com/jazzband/django-sortedm2m) to maintain a deterministic ordering of maps.