### PR TITLE
Fix episode-dict keys to match (new) short names

### DIFF
--- a/frontend/src/views/multi-episode.jsx
+++ b/frontend/src/views/multi-episode.jsx
@@ -8,10 +8,10 @@ const EPISODES = ["bc23"];
 // and the code will treat them the same way
 const EPISODE_TO_EXTENSION = { bc23: ".bc23" };
 const EPISODE_TO_SCAFFOLD_LINK = {
-  2023: "https://github.com/battlecode/battlecode23-scaffold",
+  bc23: "https://github.com/battlecode/battlecode23-scaffold",
 };
 const EPISODE_TO_SCAFFOLD_NAME = {
-  2023: "battlecode23-scaffold",
+  bc23: "battlecode23-scaffold",
 };
 const DEFAULT_EPISODE = "bc23";
 


### PR DESCRIPTION
Remember how we decided to use bc23 instead of 2023 as episode names? Forgot to port it everywhere

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/14008996/204452995-f3a68f3c-e853-432b-805f-cf360fd9d9e3.png">
yay