### PR TITLE
Fix autoscrim request content type

### DIFF
--- a/backend/siarnaq/api/episodes/signals.py
+++ b/backend/siarnaq/api/episodes/signals.py
@@ -1,3 +1,5 @@
+import json
+
 import google.cloud.scheduler as scheduler
 import structlog
 from django.conf import settings
@@ -58,7 +60,10 @@ def update_autoscrim_schedule(instance, update_fields, **kwargs):
         http_target=scheduler.HttpTarget(
             uri=url,
             http_method=scheduler.HttpMethod.POST,
-            body=f"best_of={best_of}".encode(),
+            headers={
+                "Content-Type": "application/json; charset=utf-8",
+            },
+            body=json.dumps({"best_of": best_of}).encode(),
             oidc_token=scheduler.OidcToken(
                 service_account_email=settings.GCLOUD_SERVICE_EMAIL,
             ),


### PR DESCRIPTION
```
POST  415  900 B  95 ms  Google-Cloud-Scheduler  https://api.battlecode.org/api/episode/e/bc23/autoscrim/
```

Looks like the default content-type is some nonsense. Let's specify it explicitly.