### PR TITLE
Don't remove old files from frontend bucket

### DIFF
--- a/deploy/galaxy/main.tf
+++ b/deploy/galaxy/main.tf
@@ -78,7 +78,9 @@ resource "google_cloudbuild_trigger" "this" {
     step {
       name = "gcr.io/google.com/cloudsdktool/cloud-sdk"
       entrypoint = "gsutil"
-      args = ["-m", "rsync", "-d", "-r", "build", "gs://${google_storage_bucket.frontend[count.index].name}"]
+      # Don't delete old files;
+      # those files may be requested by a user's cache or by CDN cache.
+      args = ["-m", "rsync", "-r", "build", "gs://${google_storage_bucket.frontend[count.index].name}"]
       dir = "frontend"
     }
   }

--- a/frontend/src/footer.js
+++ b/frontend/src/footer.js
@@ -12,7 +12,7 @@ class Footer extends Component {
                 <a href="/">Home</a>
               </li>
               <li>
-                <NavLink to="codeofconduct/">Code of Conduct</NavLink>
+                <NavLink to="codeofconduct">Code of Conduct</NavLink>
               </li>
             </ul>
           </nav>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -321,20 +321,13 @@ class App extends Component {
         (and so their corresponding routes are all in the fallback route's switch,
         and this fallback route includes a sidebar, etc) */}
         <Route path={`/login`} component={LoginRegister} />,
-        <Route path={`/login/`} component={LoginRegister} />,
         <Route path={`/logout`} component={LogOut} />,
-        <Route path={`/logout/`} component={LogOut} />,
         <Route path={`/register`} component={Register} />,
-        <Route path={`/register/`} component={Register} />,
         <Route path={`/multi-episode`} component={MultiEpisode} />,
-        <Route path={`/multi-episode/`} component={MultiEpisode} />,
         <Route path={`/password_forgot`} component={PasswordForgot} />,
-        <Route path={`/password_forgot/`} component={PasswordForgot} />,
         <Route path={`/password_change`} component={PasswordChange} />,
-        <Route path={`/password_change/`} component={PasswordChange} />,
         {/* To be able to render NotFound without a sidebar, etc */}
         <Route path={`/not-found`} component={NotFound} />,
-        <Route path={`/not-found/`} component={NotFound} />,
         {/* Fallback route if none of above: include sidebar, navbar, etc. */}
         <Route>
           <div className="wrapper">

--- a/frontend/src/navbar.js
+++ b/frontend/src/navbar.js
@@ -26,7 +26,7 @@ class NavBar extends Component {
             </button>
             <NavLink
               className="navbar-brand"
-              to={`/${this.props.episode}/home/`}
+              to={`/${this.props.episode}/home`}
             >
               {this.props.episode_name_long}
             </NavLink>
@@ -50,13 +50,13 @@ class NavBarAccount extends Component {
       return (
         <ul className="nav navbar-nav navbar-right">
           {/* <li>
-            <NavLink to={`/multi-episode/`}>Change Episode</NavLink>
+            <NavLink to={`/multi-episode`}>Change Episode</NavLink>
           </li> */}
           <li>
-            <NavLink to={`/${this.props.episode}/account/`}>Account</NavLink>
+            <NavLink to={`/${this.props.episode}/account`}>Account</NavLink>
           </li>
           <li>
-            <NavLink to={`/logout/`}>Log out</NavLink>
+            <NavLink to={`/logout`}>Log out</NavLink>
           </li>
         </ul>
       );
@@ -65,13 +65,13 @@ class NavBarAccount extends Component {
       return (
         <ul className="nav navbar-nav navbar-right">
           {/* <li>
-            <NavLink to={`/multi-episode/`}>Change Episode</NavLink>
+            <NavLink to={`/multi-episode`}>Change Episode</NavLink>
           </li> */}
           <li>
-            <NavLink to={`/register/`}>Register</NavLink>
+            <NavLink to={`/register`}>Register</NavLink>
           </li>
           <li>
-            <NavLink to={`/login/`}>Log in</NavLink>
+            <NavLink to={`/login`}>Log in</NavLink>
           </li>
         </ul>
       );

--- a/frontend/src/sidebar.js
+++ b/frontend/src/sidebar.js
@@ -33,7 +33,7 @@ class SideBar extends Component {
         {/* data-color is defined in light-bootstrap-dashboard.css */}
         <div className="sidebar-wrapper">
           <div className="logo text">
-            <a href={`/${this.props.episode}/home/`}>
+            <a href={`/${this.props.episode}/home`}>
               <img src="/bc/img/logo.png" />
             </a>
             <p>
@@ -49,17 +49,17 @@ class SideBar extends Component {
             {/* This invisible element is needed for proper spacing */}
             <NLink to={`#`} style={{ visibility: "hidden" }}></NLink>
             <NLink
-              to={`/${this.props.episode}/home/`}
+              to={`/${this.props.episode}/home`}
               icon={"pe-7s-home"}
               label="Home"
             />
             <NLink
-              to={`/${this.props.episode}/getting-started/`}
+              to={`/${this.props.episode}/getting-started`}
               icon={"pe-7s-sun"}
               label="Getting Started"
             />
             <NLink
-              to={`/${this.props.episode}/resources/`}
+              to={`/${this.props.episode}/resources`}
               icon={"pe-7s-note2"}
               label="Resources"
             />
@@ -73,13 +73,13 @@ class SideBar extends Component {
             <br />
 
             <NLink
-              to={`/${this.props.episode}/tournaments/`}
+              to={`/${this.props.episode}/tournaments`}
               icon={"pe-7s-medal"}
               label="Tournaments"
             />
 
             <NLink
-              to={`/${this.props.episode}/rankings/`}
+              to={`/${this.props.episode}/rankings`}
               icon={"pe-7s-graph1"}
               label="Rankings"
             />
@@ -94,7 +94,7 @@ class SideBar extends Component {
             {/* Only visible when logged in */}
             {this.props.logged_in && (
               <NLink
-                to={`/${this.props.episode}/team/`}
+                to={`/${this.props.episode}/team`}
                 icon={"pe-7s-users"}
                 label="Team"
               />
@@ -104,7 +104,7 @@ class SideBar extends Component {
             {/* Only visible when on a team AND game is released */}
             {this.props.on_team && this.props.is_game_released && (
               <NLink
-                to={`/${this.props.episode}/submissions/`}
+                to={`/${this.props.episode}/submissions`}
                 icon={"pe-7s-up-arrow"}
                 label="Submissions"
               />
@@ -117,7 +117,7 @@ class SideBar extends Component {
             - Nathan */}
             {this.props.on_team && this.props.is_game_released && (
               <NLink
-                to={`/${this.props.episode}/scrimmaging/`}
+                to={`/${this.props.episode}/scrimmaging`}
                 icon={"pe-7s-joy"}
                 label="Scrimmaging"
               />
@@ -128,7 +128,7 @@ class SideBar extends Component {
             {/* Only visible if a staff user. (No staff elements yet.) */}
             {/* {this.state.user.is_staff && (
               <NLink
-                to={`/${this.props.episode}/staff/`}
+                to={`/${this.props.episode}/staff`}
                 icon={"pe-7s-tools"}
                 label="Staff"
               />

--- a/frontend/src/views/getting-started.js
+++ b/frontend/src/views/getting-started.js
@@ -265,7 +265,7 @@ class GettingStarted extends Component {
                   </p>
                   <p>
                     Create an account on this website, and then go to the{" "}
-                    <NavLink to="team/" style={{ fontWeight: 700 }}>
+                    <NavLink to="team" style={{ fontWeight: 700 }}>
                       team
                     </NavLink>{" "}
                     section to either create or join a team.
@@ -280,7 +280,7 @@ class GettingStarted extends Component {
                   <p>
                     <b>
                       Check{" "}
-                      <NavLink to="common-issues/" style={{ fontWeight: 700 }}>
+                      <NavLink to="common-issues" style={{ fontWeight: 700 }}>
                         common issues
                       </NavLink>{" "}
                       if you experience problems with the instructions below,
@@ -483,7 +483,7 @@ class GettingStarted extends Component {
                   <p>
                     Once you're all set up, make sure to check out the{" "}
                     <NavLink
-                      to={`/${this.props.episode}/resources/`}
+                      to={`/${this.props.episode}/resources`}
                       style={{ fontWeight: 700 }}
                     >
                       resources

--- a/frontend/src/views/issues.js
+++ b/frontend/src/views/issues.js
@@ -201,7 +201,7 @@ class Issues extends Component {
                       <li>
                         Did you download the Oracle JDK 8 listed in{" "}
                         <NavLink
-                          to="getting-started/"
+                          to="getting-started"
                           style={{ fontWeight: 700 }}
                         >
                           the installation instructions

--- a/frontend/src/views/resources.js
+++ b/frontend/src/views/resources.js
@@ -43,7 +43,7 @@ class Resources extends Component {
                   <p>
                     If you're just starting out, check out the{" "}
                     <NavLink
-                      to={`/${this.props.episode}/getting-started/`}
+                      to={`/${this.props.episode}/getting-started`}
                       style={{ fontWeight: 700 }}
                     >
                       getting started


### PR DESCRIPTION
In case a cache (at some level of caching) asks for them.
In particular, consider the Cloud CDN serving an old (cached) HTML file that has a link to an old, now-purged js file. But the js file was never cached. Things go south.

Also removes the "add trailing slash", cuz it turns out that adding trailing slash was a workaround and bandaid, but not a fix for the underlying problem.