### PR TITLE
Add a generic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-or-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-or-feature-request.md
@@ -12,3 +12,5 @@ Although not required, these would be great if you can:
 - [ ] Assign a label (or labels) for module. (the green labels)
 - [ ] Assign a label (or labels) for type. (the yellow labels)
 - [ ] If this is a simple issue or fix, assign "good first issue". (the blue label)
+
+When you're done with each item, you can delete the template's text!

--- a/.github/ISSUE_TEMPLATE/bug-report-or-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-or-feature-request.md
@@ -1,10 +1,14 @@
 ---
 name: Bug Report or Feature Request
 about: General Issue template for Galaxy.
-title: ''
+title: ""
 labels: triage
-assignees: ''
-
+assignees: ""
 ---
 
-Please **label** this with the corresponding module, type, and priority (or keep the "triage" label if you don't know any of these). Also, if a fix seems simple, please label with "good first issue".
+Although not required, these would be great if you can:
+
+- [ ] Assign a label for priority. (the red labels. or if you don't know the priority, "triage", the black label)
+- [ ] Assign a label (or labels) for module. (the green labels)
+- [ ] Assign a label (or labels) for type. (the yellow labels)
+- [ ] If this is a simple issue or fix, assign "good first issue". (the blue label)

--- a/.github/ISSUE_TEMPLATE/bug-report-or-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-or-feature-request.md
@@ -6,11 +6,18 @@ labels: triage
 assignees: ""
 ---
 
-Although not required, these would be great if you can:
+# Before you submit this issue...
 
-- [ ] Assign a label for priority. (the red labels. or if you don't know the priority, "triage", the black label)
-- [ ] Assign a label (or labels) for module. (the green labels)
-- [ ] Assign a label (or labels) for type. (the yellow labels)
-- [ ] If this is a simple issue or fix, assign "good first issue". (the blue label)
+**If you are not a Battlecode dev, please keep the `triage` label.**
 
-When you're done with each item, you can delete the template's text!
+If you are a Battlecode dev, the following would be great, but optional.
+
+- [ ] If you know the priority, assign a label for it. (the red labels)
+- [ ] If you know the module(s), assign a label (or labels) for it. (the green labels)
+- [ ] If you know the type(s), assign a label (or labels) for it. (the yellow labels)
+- [ ] If you know this is a simple issue or fix, assign `good first issue`. (the blue label)
+- [ ] If you did not fill any of the above, please keep the `triage` label.
+
+# Description
+
+Please include a description of the issue below, including steps to reproduce.

--- a/.github/ISSUE_TEMPLATE/bug-report-or-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-or-feature-request.md
@@ -1,0 +1,10 @@
+---
+name: Bug Report or Feature Request
+about: General Issue template for Galaxy.
+title: ''
+labels: triage
+assignees: ''
+
+---
+
+Please **label** this with the corresponding module, type, and priority (or keep the "triage" label if you don't know any of these). Also, if a fix seems simple, please label with "good first issue".


### PR DESCRIPTION
closes #119 

**idea: when merged, what if we put the new link issue in the bug report channel, and either pin it (and change the channel description to make ppl see the pins) or put it smack in description?**