### PR TITLE
Saturn enhancements

### DIFF
--- a/backend/siarnaq/api/compete/managers.py
+++ b/backend/siarnaq/api/compete/managers.py
@@ -57,7 +57,6 @@ class SaturnInvokableQuerySet(models.QuerySet):
                     message_id=message_id,
                 )
                 invocation.status = SaturnStatus.QUEUED
-                invocation.logs = f"Enqueued with ID: {message_id}"
                 invocation.num_failures = 0
             except Exception as err:
                 log.error(
@@ -70,7 +69,9 @@ class SaturnInvokableQuerySet(models.QuerySet):
                     topic=topic,
                     ordering_key=self._publish_ordering_key,
                 )
-                invocation.logs = f"type: {type(err)} Exception message: {err}"
+                invocation.logs = (
+                    invocation.logs + f"Exception {type(err)} on enqueue!\n{err}\n"
+                )
         self.model.objects.bulk_update(invocations, ["status", "logs", "num_failures"])
 
 

--- a/backend/siarnaq/api/compete/models.py
+++ b/backend/siarnaq/api/compete/models.py
@@ -247,6 +247,7 @@ class Match(SaturnInvocation):
             for p in self.participants.all()
         }
         return {
+            "maps": [m.name for m in self.maps.all()],
             "replay": {
                 "bucket": settings.GCLOUD_BUCKET_SECURE,
                 "name": self.get_replay_path(),

--- a/deploy/saturn/main.tf
+++ b/deploy/saturn/main.tf
@@ -23,6 +23,18 @@ resource "google_artifact_registry_repository_iam_member" "this" {
   member     = "serviceAccount:${google_service_account.this.email}"
 }
 
+resource "google_project_iam_member" "log" {
+  project = var.gcp_project
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.this.email}"
+}
+
+resource "google_project_iam_member" "monitoring" {
+  project = var.gcp_project
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.this.email}"
+}
+
 resource "google_pubsub_subscription" "queue" {
   name  = var.name
   topic = var.pubsub_topic_name

--- a/saturn/pkg/run/java8.go
+++ b/saturn/pkg/run/java8.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/battlecode/galaxy/saturn/pkg/saturn"
 	"github.com/go-git/go-git/v5"
@@ -168,6 +169,7 @@ func (s *Java8Scaffold) RunMatch() *Step {
 				fmt.Sprintf("-PclassLocationB=%s", filepath.Join("data", "B")),
 				fmt.Sprintf("-PpackageNameA=%s", arg.Details.(ExecuteRequest).A.Package),
 				fmt.Sprintf("-PpackageNameB=%s", arg.Details.(ExecuteRequest).B.Package),
+				fmt.Sprintf("-Pmaps=%s", strings.Join(arg.Details.(ExecuteRequest).Maps, ",")),
 				fmt.Sprintf("-Preplay=%s", filepath.Join("data", "replay.bin")),
 				fmt.Sprintf("-PoutputVerbose=%t", false),
 				fmt.Sprintf("-PshowIndicators=%t", false),

--- a/saturn/pkg/run/protocol.go
+++ b/saturn/pkg/run/protocol.go
@@ -14,6 +14,7 @@ type CompileRequest struct {
 type ExecuteRequest struct {
 	A      Submission        `mapstructure:"a"`
 	B      Submission        `mapstructure:"b"`
+	Maps   []string          `mapstructure:"maps"`
 	Replay FileSpecification `mapstructure:"replay"`
 }
 

--- a/saturn/pkg/run/recipe.go
+++ b/saturn/pkg/run/recipe.go
@@ -22,7 +22,7 @@ type Step struct {
 
 func (s *Step) Run(ctx context.Context, desc string, arg *StepArguments) error {
 	log.Ctx(ctx).Debug().Msgf(">>> Starting %s: %s", desc, s.Name)
-	defer log.Ctx(ctx).Debug().Msgf(">>> Ending %s", desc)
+	defer log.Ctx(ctx).Debug().Msgf(">>> Ending %s\n", desc)
 	return s.Callable(ctx, arg)
 }
 

--- a/saturn/pkg/run/scaffold.go
+++ b/saturn/pkg/run/scaffold.go
@@ -160,9 +160,9 @@ func (s *Scaffold) Refresh(ctx context.Context) error {
 	log.Ctx(ctx).Debug().Msg("Pulling scaffold.")
 	switch err := wt.PullContext(ctx, &git.PullOptions{Auth: s.gitAuth}); true {
 	case err == nil:
-		log.Ctx(ctx).Debug().Msg("New scaffold version downloaded.")
+		log.Ctx(ctx).Debug().Msg("> New scaffold version downloaded.")
 	case errors.Is(err, git.NoErrAlreadyUpToDate):
-		log.Ctx(ctx).Debug().Msg("Already up to date.")
+		log.Ctx(ctx).Debug().Msg("> Already up to date.")
 	default:
 		return fmt.Errorf("wt.PullContext: %v", err)
 	}

--- a/saturn/pkg/saturn/report.go
+++ b/saturn/pkg/saturn/report.go
@@ -37,9 +37,13 @@ func (r *GCPTokenedReporter) Report(ctx context.Context, t *Task) error {
 	for k, v := range t.details {
 		payload[k] = v
 	}
+	logs, err := ioutil.ReadAll(&t.logs)
+	if err != nil {
+		return fmt.Errorf("ioutil.ReadAll: %v", err)
+	}
 	payload["invocation"] = map[string]interface{}{
 		"status":      t.status.String(),
-		"logs":        t.logs.String(),
+		"logs":        string(logs),
 		"interrupted": t.status == TaskInterrupted,
 	}
 


### PR DESCRIPTION
Essentially resolves todo list from #450; see below:
- Actually run the set of requested maps, instead of just maptestsmall.
- Grant permissions for logs to actually get written.
- Make logs more beautiful. Resolved siarnaq-side logging race condition by eliminating those log lines.

Other tasks completed:
- Instance pre-emption is handled very gracefully.

Remaining tasks to do:
- Investigate machine sizing vs runtime tradeoff.