### PR TITLE
Fix nonetype on match score

### DIFF
--- a/backend/siarnaq/api/compete/serializers.py
+++ b/backend/siarnaq/api/compete/serializers.py
@@ -325,6 +325,7 @@ class MatchReportSerializer(serializers.Serializer):
             participant.score = score
         MatchParticipant.objects.bulk_update(participants, ["score"])
 
+        self.instance.refresh_from_db()
         invocation_serializer = self.fields["invocation"]
         invocation_serializer.update(self.instance, self.validated_data["invocation"])
         return self.instance


### PR DESCRIPTION
Closes #476, I think.

Issue hypothesis: `self.instance` has pre-fetched all the match participants, so the bulk update doesn't propagate through. Therefore it's trying to add up a bunch of NoneTypes when calculating ratings.