### PR TITLE
Small changes to scrimmage request team search

### DIFF
--- a/frontend/src/components/rankingTeamList.js
+++ b/frontend/src/components/rankingTeamList.js
@@ -85,7 +85,10 @@ class RankingTeamList extends Component {
         </div>
       );
     } else {
-      const teamRows = props.teams.map((team) => {
+      const teamsToShow = props.teams.filter((team) => {
+        return team.has_active_submission || !this.props.canRequest;
+      });
+      const teamRows = teamsToShow.map((team) => {
         let buttonContent = "Request";
         if (state.pendingRequests[team.id]) {
           buttonContent = <i className="fa fa-circle-o-notch fa-spin"></i>;
@@ -127,9 +130,6 @@ class RankingTeamList extends Component {
                   }
                 )}
               </td>
-            )}
-            {this.props.canRequest && (
-              <td>{team.has_active_submission ? "Yes" : "No"}</td>
             )}
             <td>{team.profile.auto_accept_ranked ? "Yes" : "No"}</td>
             <td>{team.profile.auto_accept_unranked ? "Yes" : "No"}</td>
@@ -182,7 +182,6 @@ class RankingTeamList extends Component {
                     <th>Members</th>
                     {!this.props.canRequest && <th>Quote</th>}
                     {!this.props.canRequest && <th>Eligibility</th>}
-                    {this.props.canRequest && <th>Submitted?</th>}
                     <th>Auto-Accept Ranked</th>
                     <th>Auto-Accept Unranked</th>
                   </tr>

--- a/frontend/src/components/rankingTeamList.js
+++ b/frontend/src/components/rankingTeamList.js
@@ -114,7 +114,7 @@ class RankingTeamList extends Component {
                 </span>
               ))}
             </td>
-            {!this.props.canRequest && <td>{team.profile.quote}</td>}
+            <td>{team.profile.quote}</td>
             {!this.props.canRequest && (
               <td>
                 {this.props.episode_info.eligibility_criteria.map(
@@ -180,7 +180,7 @@ class RankingTeamList extends Component {
                     <th>Rating</th>
                     <th>Team</th>
                     <th>Members</th>
-                    {!this.props.canRequest && <th>Quote</th>}
+                    <th>Quote</th>
                     {!this.props.canRequest && <th>Eligibility</th>}
                     <th>Auto-Accept Ranked</th>
                     <th>Auto-Accept Unranked</th>

--- a/frontend/src/components/scrimmageRequestForm.js
+++ b/frontend/src/components/scrimmageRequestForm.js
@@ -35,10 +35,10 @@ class ScrimmageRequestForm extends Component {
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
-    let is_ranked =
-      this.props.team === null ||
-      ALLOWS_RANKED.includes(this.props.team.status);
-    if (is_ranked != this.state.is_ranked) {
+    if (prevProps.team !== this.props.team) {
+      let is_ranked =
+        this.props.team === null ||
+        ALLOWS_RANKED.includes(this.props.team.status);
       this.setState({ is_ranked });
     }
   }

--- a/frontend/src/components/scrimmageRequestForm.js
+++ b/frontend/src/components/scrimmageRequestForm.js
@@ -16,7 +16,7 @@ class ScrimmageRequestForm extends Component {
     super(props);
 
     this.state = {
-      is_ranked: true,
+      is_ranked: false,
       player_order: PLAYER_ORDERS[0].value,
       maps: ["", "", ""],
       available_maps: [],
@@ -107,7 +107,7 @@ class ScrimmageRequestForm extends Component {
     // Reset state
     const random_maps = this.getRandomMaps(this.state.available_maps);
     this.setState({
-      is_ranked: true,
+      is_ranked: false,
       player_order: PLAYER_ORDERS[0].value,
       maps: random_maps,
     });
@@ -209,6 +209,10 @@ class ScrimmageRequestForm extends Component {
                     }}
                     id="is_ranked"
                     checked={this.state.is_ranked}
+                    // Only regular teams get ranked matches
+                    disabled={
+                      this.props.team !== null && this.props.team.status != "R"
+                    }
                   />
                 </div>
               </div>

--- a/frontend/src/components/scrimmageRequestForm.js
+++ b/frontend/src/components/scrimmageRequestForm.js
@@ -11,12 +11,15 @@ const PLAYER_ORDERS = [
   { value: "-", name: "Requester last" },
 ];
 
+// Team statuses that allow ranked matches.
+const ALLOWS_RANKED = ["R"];
+
 class ScrimmageRequestForm extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      is_ranked: false,
+      is_ranked: true,
       player_order: PLAYER_ORDERS[0].value,
       maps: ["", "", ""],
       available_maps: [],
@@ -29,6 +32,15 @@ class ScrimmageRequestForm extends Component {
     this.changeHandler = this.changeHandler.bind(this);
     this.closeModal = this.closeModal.bind(this);
     this.requestScrimmage = this.requestScrimmage.bind(this);
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    let is_ranked =
+      this.props.team === null ||
+      ALLOWS_RANKED.includes(this.props.team.status);
+    if (is_ranked != this.state.is_ranked) {
+      this.setState({ is_ranked });
+    }
   }
 
   getRandomMaps(available_maps) {
@@ -107,7 +119,7 @@ class ScrimmageRequestForm extends Component {
     // Reset state
     const random_maps = this.getRandomMaps(this.state.available_maps);
     this.setState({
-      is_ranked: false,
+      is_ranked: true,
       player_order: PLAYER_ORDERS[0].value,
       maps: random_maps,
     });
@@ -211,7 +223,8 @@ class ScrimmageRequestForm extends Component {
                     checked={this.state.is_ranked}
                     // Only regular teams get ranked matches
                     disabled={
-                      this.props.team !== null && this.props.team.status != "R"
+                      this.props.team !== null &&
+                      !ALLOWS_RANKED.includes(this.props.team.status)
                     }
                   />
                 </div>


### PR DESCRIPTION
- Teams without an active submission: remove them entirely from the list.
- Disallow ranked matches against staff. It's enforced by backend, so let's enforce on frontend too. As a side-effect, matches now default to unranked.
- Show team quote (useful because Dev team contains message about "we're running examplefuncs!")