### PR TITLE
Address #74

### DIFF
--- a/frontend/src/sidebar.js
+++ b/frontend/src/sidebar.js
@@ -101,7 +101,6 @@ class SideBar extends Component {
               />
             )}
 
-            {/* #74 considers combining these two checks and &&, into one*/}
             {/* Only visible when on a team AND game is released */}
             {this.props.on_team && this.props.is_game_released && (
               <NLink


### PR DESCRIPTION
Removes a TODO that I considered, but on second thought it's fine. It's a simple duped thing, and only occurs twice. More importantly, that de-dupe is actually nontrivial (cuz the parts get used elsewhere). And the code is simple enough now thanks to auxiliary changes.

For security bugs / permission checks: carefully went through, and couldn't find anything. Also people haven't broken prod yet, which is good!!
I think we can release now, and let people file bugs as necessary. But our own internal QA is probably good (at least with regards to this issue)