### PR TITLE
Disable auto-accept for ranked scrimmages (and do nothing else)

### DIFF
--- a/backend/siarnaq/api/compete/signals.py
+++ b/backend/siarnaq/api/compete/signals.py
@@ -30,9 +30,12 @@ def auto_accept_scrimmage(instance, created, **kwargs):
     """Automatically accept a scrimmage request if the team prefers to do so."""
     if not created:
         return
-    if (instance.is_ranked and instance.requested_to.profile.auto_accept_ranked) or (
-        not instance.is_ranked and instance.requested_to.profile.auto_accept_unranked
-    ):
+    # if (instance.is_ranked and instance.requested_to.profile.auto_accept_ranked) or (
+    #     not instance.is_ranked and instance.requested_to.profile.auto_accept_unranked
+    # ):
+    # NOTE: we disable auto-accept for ranked scrimmages for now.
+    # Is a hotfix patch, can figure out better solution later.
+    if not instance.is_ranked and instance.requested_to.profile.auto_accept_unranked:
         # Must wait for transaction to complete, so that maps are inserted.
         transaction.on_commit(
             lambda: ScrimmageRequest.objects.filter(pk=instance.pk).accept()

--- a/backend/siarnaq/api/compete/test_views.py
+++ b/backend/siarnaq/api/compete/test_views.py
@@ -1,6 +1,7 @@
 import io
 import random
 from datetime import timedelta
+from unittest import skip
 from unittest.mock import mock_open, patch
 
 from django.test import TestCase, override_settings
@@ -1160,6 +1161,11 @@ class ScrimmageRequestViewSetTestCase(APITransactionTestCase):
     @patch(
         "siarnaq.api.compete.managers.SaturnInvokableQuerySet.enqueue", autospec=True
     )
+    @skip("Code behavior has changed temporarily")
+    # Skipped for now, as ranked scrimmage requests are never auto-accepted
+    # regardless of user setting.
+    # Is a quick fix and subject to change on further discussion.
+    # See #565.
     def test_create_autoaccept(self, enqueue):
         self.client.force_authenticate(self.users[0])
         self.teams[1].profile.auto_accept_ranked = True


### PR DESCRIPTION
As discussed here's the quick braindead fix for now (cuz time press). 

UI/UX is probably now weird. Should announce in discord (and make frontend more intuitive later, like in Maggie's PR?)