### PR TITLE
Revert "Do not run map validation"

### DIFF
--- a/saturn/pkg/run/java8.go
+++ b/saturn/pkg/run/java8.go
@@ -182,7 +182,6 @@ func (s *Java8Scaffold) RunMatch() *Step {
 				fmt.Sprintf("-PpackageNameA=%s", arg.Details.(ExecuteRequest).A.Package),
 				fmt.Sprintf("-PpackageNameB=%s", arg.Details.(ExecuteRequest).B.Package),
 				fmt.Sprintf("-Pmaps=%s", strings.Join(arg.Details.(ExecuteRequest).Maps, ",")),
-				fmt.Sprintf("-PvalidateMaps=%t", false),
 				fmt.Sprintf("-Preplay=%s", filepath.Join("data", "replay.bin")),
 				fmt.Sprintf("-PalternateOrder=%t", arg.Details.(ExecuteRequest).AlternateOrder),
 				fmt.Sprintf("-PoutputVerbose=%t", false),


### PR DESCRIPTION
**Hold deploy pending actual map fixes, just for cleanliness/sanity**

Reverts battlecode/galaxy#532

Turns out, there's major cost in not running map validation -- sometimes we forget to validate on our own! This leads to rough tournaments.

(And the time/money saved by skipping this step is marginal and not worth)