### PR TITLE
Add tooltip

### DIFF
--- a/frontend2/src/components/elements/Tooltip.tsx
+++ b/frontend2/src/components/elements/Tooltip.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+// Example usage
+// <Tooltip content="This will be displayed inside the tooltip" location="left">
+//   <p>Hovering this makes the tooltip appear</p>
+// </Tooltip>
+
+interface TooltipProps {
+  children?: React.ReactNode;
+  content: string;
+  delay?: number;
+  location?: "top" | "bottom" | "left" | "right";
+}
+
+const TOOLTIP_CLASSES = {
+  top: "bottom-full left-1/2 -translate-x-1/2 mb-2",
+  bottom: "top-full left-1/2 -translate-x-1/2 mt-2",
+  left: "right-full top-1/2 -translate-y-1/2 mr-2",
+  right: "left-full top-1/2 -translate-y-1/2 ml-2",
+};
+const TOOLTIP_TRIANGLE_CLASSES = {
+  top: "-bottom-1 left-1/2 -translate-x-1/2",
+  bottom: "-top-1 left-1/2 -translate-x-1/2",
+  left: "-right-1 top-1/2 -translate-y-1/2",
+  right: "-left-1 top-1/2 -translate-y-1/2",
+};
+
+const Tooltip: React.FC<TooltipProps> = ({
+  children,
+  // the string to display inside the tooltip
+  content,
+  // delay between hover and tooltip appearance, in ms.
+  delay = 400,
+  // the location that the tooltip will appear (relative to the children)
+  location = "top",
+}) => {
+  return (
+    <div className={`group relative h-max w-max`}>
+      {children}
+      <div
+        className={`pointer-events-none absolute z-20 mb-1 w-max max-w-[200px] rounded bg-gray-800 px-2 py-1
+        text-center text-sm text-gray-50 opacity-0 transition-opacity delay-0 group-hover:opacity-100
+        group-hover:delay-[${delay}ms] ${TOOLTIP_CLASSES[location]}`}
+      >
+        {content}
+        <div
+          className={`absolute z-20 h-2.5 w-2.5 rotate-45 transform
+          bg-gray-800 ${TOOLTIP_TRIANGLE_CLASSES[location]}`}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/frontend2/src/components/elements/Tooltip.tsx
+++ b/frontend2/src/components/elements/Tooltip.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
 // Example usage
-// <Tooltip content="This will be displayed inside the tooltip" location="left">
+// <Tooltip text="This will be displayed inside the tooltip" location="left">
 //   <p>Hovering this makes the tooltip appear</p>
 // </Tooltip>
 
 interface TooltipProps {
   children?: React.ReactNode;
-  content: string;
+  text: string;
   delay?: number;
   location?: "top" | "bottom" | "left" | "right";
 }
@@ -28,7 +28,7 @@ const TOOLTIP_TRIANGLE_CLASSES = {
 const Tooltip: React.FC<TooltipProps> = ({
   children,
   // the string to display inside the tooltip
-  content,
+  text,
   // delay between hover and tooltip appearance, in ms.
   delay = 400,
   // the location that the tooltip will appear (relative to the children)
@@ -42,7 +42,7 @@ const Tooltip: React.FC<TooltipProps> = ({
         text-center text-sm text-gray-50 opacity-0 transition-opacity delay-0 group-hover:opacity-100
         group-hover:delay-[${delay}ms] ${TOOLTIP_CLASSES[location]}`}
       >
-        {content}
+        {text}
         <div
           className={`absolute z-20 h-2.5 w-2.5 rotate-45 transform
           bg-gray-800 ${TOOLTIP_TRIANGLE_CLASSES[location]}`}


### PR DESCRIPTION
![image](https://github.com/battlecode/galaxy/assets/40174697/83af419f-1a1a-40db-9f98-b53e8af7cc71)

example usage:
```
<Tooltip text="this is part of the tooltip.">
  <p className="text-pink-500">the default location for a tooltip is top</p>
</Tooltip>
<Tooltip location="right" text="This is an incredibly long tooltip text that should wrap nicely">
  <Icon name="arrow_up_tray" size="sm" />
</Tooltip>
<Tooltip location="left" text="This is an incredibly long tooltip text that should wrap nicely">
  <Icon name="map" size="sm" />
</Tooltip>
<Tooltip location="bottom" text="short tooltip">
  <Icon name="map" size="sm" />
</Tooltip>
```
