### PR TITLE
Add team sidebar display conditions

### DIFF
--- a/frontend2/src/components/sidebar/__test__/Sidebar.test.tsx
+++ b/frontend2/src/components/sidebar/__test__/Sidebar.test.tsx
@@ -2,7 +2,35 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import Sidebar from "../";
 import { EpisodeIdContext } from "../../../contexts/EpisodeContext";
+import { CurrentUserContext } from "../../../contexts/CurrentUserContext";
+import {
+  CurrentTeamContext,
+  TeamStateEnum,
+} from "../../../contexts/CurrentTeamContext";
 import { MemoryRouter } from "react-router-dom";
+import { Status526Enum } from "../../../utils/types";
+
+const mem = {
+  id: 123,
+  username: "theuser",
+  is_staff: false,
+};
+const faketeam = {
+  id: 123,
+  episode: "bc23",
+  name: "theteam",
+  members: [mem],
+  join_key: "abc",
+  status: Status526Enum.O,
+};
+const fakeuser = {
+  id: 123,
+  username: "theuser",
+  email: "user@gmail.com",
+  first_name: "the",
+  last_name: "user",
+  is_staff: false,
+};
 
 test("UI: should collapse sidebar", () => {
   render(
@@ -10,7 +38,24 @@ test("UI: should collapse sidebar", () => {
       <EpisodeIdContext.Provider
         value={{ episodeId: "something", setEpisodeId: (_) => undefined }}
       >
-        <Sidebar collapsed={true} />
+        <CurrentTeamContext.Provider
+          value={{ teamState: TeamStateEnum.IN_TEAM, team: faketeam }}
+        >
+          <CurrentUserContext.Provider
+            value={{
+              authState: "loading",
+              user: fakeuser,
+              login: (_) => {
+                console.log();
+              },
+              logout: () => {
+                console.log();
+              },
+            }}
+          >
+            <Sidebar collapsed={true} />
+          </CurrentUserContext.Provider>
+        </CurrentTeamContext.Provider>
       </EpisodeIdContext.Provider>
     </MemoryRouter>,
   );
@@ -23,7 +68,24 @@ test("UI: should link to episode in surrounding context", () => {
       <EpisodeIdContext.Provider
         value={{ episodeId: "something", setEpisodeId: (_) => undefined }}
       >
-        <Sidebar />
+        <CurrentTeamContext.Provider
+          value={{ teamState: TeamStateEnum.IN_TEAM, team: faketeam }}
+        >
+          <CurrentUserContext.Provider
+            value={{
+              authState: "loading",
+              user: fakeuser,
+              login: (_) => {
+                console.log();
+              },
+              logout: () => {
+                console.log();
+              },
+            }}
+          >
+            <Sidebar />
+          </CurrentUserContext.Provider>
+        </CurrentTeamContext.Provider>
       </EpisodeIdContext.Provider>
     </MemoryRouter>,
   );

--- a/frontend2/src/components/sidebar/index.tsx
+++ b/frontend2/src/components/sidebar/index.tsx
@@ -4,7 +4,6 @@ import SidebarItem from "./SidebarItem";
 import { useEpisodeId } from "../../contexts/EpisodeContext";
 import { type IconName } from "../elements/Icon";
 import { useCurrentUser } from "../../contexts/CurrentUserContext";
-import { isNull } from "lodash";
 import { useCurrentTeam } from "../../contexts/CurrentTeamContext";
 
 interface SidebarProps {
@@ -98,8 +97,8 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
   let teamManage;
 
   // construct teamManage if needed
-  if (!isNull(user) && user !== undefined) {
-    if (!isNull(team) && team !== undefined) {
+  if (user !== undefined) {
+    if (team !== undefined) {
       teamManage = (
         <SidebarSection title="team management">
           {generateSidebarItems(6, 8, episodeId)}

--- a/frontend2/src/components/sidebar/index.tsx
+++ b/frontend2/src/components/sidebar/index.tsx
@@ -3,6 +3,9 @@ import SidebarSection from "./SidebarSection";
 import SidebarItem from "./SidebarItem";
 import { useEpisodeId } from "../../contexts/EpisodeContext";
 import { type IconName } from "../elements/Icon";
+import { useCurrentUser } from "../../contexts/CurrentUserContext";
+import { isNull } from "lodash";
+import { useCurrentTeam } from "../../contexts/CurrentTeamContext";
 
 interface SidebarProps {
   collapsed?: boolean;
@@ -90,7 +93,28 @@ export const generateSidebarItems = (
 const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
   collapsed = collapsed ?? false;
   const { episodeId } = useEpisodeId();
+  const { user } = useCurrentUser();
+  const { team } = useCurrentTeam();
+  let teamManage;
 
+  // construct teamManage if needed
+  if (!isNull(user) && user !== undefined) {
+    if (!isNull(team) && team !== undefined) {
+      teamManage = (
+        <SidebarSection title="team management">
+          {generateSidebarItems(6, 8, episodeId)}
+        </SidebarSection>
+      );
+    } else {
+      teamManage = (
+        <SidebarSection title="team management">
+          {generateSidebarItems(6, 6, episodeId)}
+        </SidebarSection>
+      );
+    }
+  }
+
+  // generate sidebar
   return collapsed ? null : (
     <nav className="fixed top-16 z-10 hidden h-full w-52 flex-col gap-8 bg-gray-50 py-4 drop-shadow-[2px_0_2px_rgba(0,0,0,0.25)] sm:flex">
       <SidebarSection title="">
@@ -99,9 +123,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
       <SidebarSection title="compete">
         {generateSidebarItems(3, 5, episodeId)}
       </SidebarSection>
-      <SidebarSection title="team management">
-        {generateSidebarItems(6, 8, episodeId)}
-      </SidebarSection>
+      {teamManage}
     </nav>
   );
 };


### PR DESCRIPTION
If the user is not logged in, the entire TEAM MANAGEMENT section of the sidebar should not appear
If the user is logged in and does not have a team, the Submissions and Scrimmaging sections should not appear
If the user is logged in and has a team, the entire TEAM MANAGEMENT section should appear