### PR TITLE
add updateteampartial api call, add refreshTeam to team context

### DIFF
--- a/frontend2/src/components/sidebar/__test__/Sidebar.test.tsx
+++ b/frontend2/src/components/sidebar/__test__/Sidebar.test.tsx
@@ -45,6 +45,8 @@ test("UI: should collapse sidebar", () => {
             leaveMyTeam: async (): Promise<void> => {
               await Promise.resolve();
             },
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            refreshTeam: (team): void => {},
           }}
         >
           <CurrentUserContext.Provider
@@ -81,6 +83,8 @@ test("UI: should link to episode in surrounding context", () => {
             leaveMyTeam: async (): Promise<void> => {
               await Promise.resolve();
             },
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            refreshTeam: (team): void => {},
           }}
         >
           <CurrentUserContext.Provider

--- a/frontend2/src/contexts/CurrentTeamContext.ts
+++ b/frontend2/src/contexts/CurrentTeamContext.ts
@@ -13,7 +13,19 @@ export enum TeamStateEnum {
 interface CurrentTeamContextType {
   teamState: TeamStateEnum;
   team?: TeamPrivate;
+  /**
+   * Leaves the current user's team for the current episode
+   * The current user should be on team in the current episode before calling
+   * this function.
+   */
   leaveMyTeam: () => Promise<void>;
+  /**
+   * Replaces the TeamPrivate value in the context with a new value. Used to
+   * refresh the value upon receiving updated values from API calls.
+   * The current user must be on a team in the current episode
+   * before calling this function.
+   * @param updatedTeam The new team value to store in the context.
+   */
   refreshTeam: (updatedTeam: TeamPrivate) => void;
 }
 

--- a/frontend2/src/contexts/CurrentTeamContext.ts
+++ b/frontend2/src/contexts/CurrentTeamContext.ts
@@ -14,6 +14,7 @@ interface CurrentTeamContextType {
   teamState: TeamStateEnum;
   team?: TeamPrivate;
   leaveMyTeam: () => Promise<void>;
+  refreshTeam: (updatedTeam: TeamPrivate) => void;
 }
 
 export const CurrentTeamContext = createContext<CurrentTeamContextType | null>(

--- a/frontend2/src/contexts/CurrentTeamProvider.tsx
+++ b/frontend2/src/contexts/CurrentTeamProvider.tsx
@@ -24,6 +24,13 @@ export const CurrentTeamProvider: React.FC<{ children: React.ReactNode }> = ({
     setTeamData({ teamState: TeamStateEnum.NO_TEAM });
   }, [episodeId]);
 
+  const refreshTeam = useCallback((updatedTeam: TeamPrivate): void => {
+    setTeamData({
+      team: updatedTeam,
+      teamState: TeamStateEnum.IN_TEAM,
+    });
+  }, []);
+
   useEffect(() => {
     const loadTeam = async (): Promise<void> => {
       try {
@@ -44,7 +51,9 @@ export const CurrentTeamProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [authState, episodeId]);
 
   return (
-    <CurrentTeamContext.Provider value={{ ...teamData, leaveMyTeam }}>
+    <CurrentTeamContext.Provider
+      value={{ ...teamData, leaveMyTeam, refreshTeam }}
+    >
       {children}
     </CurrentTeamContext.Provider>
   );

--- a/frontend2/src/utils/api/team.ts
+++ b/frontend2/src/utils/api/team.ts
@@ -6,6 +6,7 @@ import {
   type TeamTListRequest,
   type TeamTAvatarCreateRequest,
   type TeamPrivate,
+  type TeamProfilePrivateRequest,
 } from "../types";
 import { DEFAULT_API_CONFIGURATION } from "./helpers";
 
@@ -61,6 +62,22 @@ export const leaveTeam = async (episodeId: string): Promise<void> => {
  */
 export const retrieveTeam = async (episodeId: string): Promise<TeamPrivate> => {
   return await API.teamTMeRetrieve({ episodeId });
+};
+
+/**
+ * Push a partial update to the current user's team for a specific episode.
+ * @param episodeId The episode of the team
+ * @param teamProfilePrivateRequest The partial team update
+ * @returns The updated TeamPrivate object
+ */
+export const updateTeamPartial = async (
+  episodeId: string,
+  teamProfilePrivateRequest: TeamProfilePrivateRequest,
+): Promise<TeamPrivate> => {
+  return await API.teamTMePartialUpdate({
+    episodeId,
+    patchedTeamPrivateRequest: { profile: teamProfilePrivateRequest },
+  });
 };
 
 // -- TEAM STATS --//

--- a/frontend2/src/utils/api/team.ts
+++ b/frontend2/src/utils/api/team.ts
@@ -66,6 +66,7 @@ export const retrieveTeam = async (episodeId: string): Promise<TeamPrivate> => {
 
 /**
  * Push a partial update to the current user's team for a specific episode.
+ * The current user must be on a team in the provided episode.
  * @param episodeId The episode of the team
  * @param teamProfilePrivateRequest The partial team update
  * @returns The updated TeamPrivate object


### PR DESCRIPTION
Add refreshTeam() to team context to enable updates of team state (needed for the Create/Join Team and My Team pages)
Add updateTeamPartial() api call (needed for My Team page)

will unblock @sri240 for create/join team