### PR TITLE
Support changing eligibility and scrim settings

### DIFF
--- a/frontend2/src/components/Loading.tsx
+++ b/frontend2/src/components/Loading.tsx
@@ -5,7 +5,7 @@ const Loading: React.FC = () => {
   return (
     <>
       Loading...
-      <Spinner size="lg" />
+      <Spinner size="xl" />
     </>
   );
 };

--- a/frontend2/src/components/PrivateRoute.tsx
+++ b/frontend2/src/components/PrivateRoute.tsx
@@ -14,7 +14,7 @@ const PrivateRoute: React.FC = () => {
   } else {
     return (
       <div className="flex h-screen items-center justify-center">
-        <Spinner size="lg" />
+        <Spinner size="xl" />
       </div>
     );
   }

--- a/frontend2/src/components/Spinner.tsx
+++ b/frontend2/src/components/Spinner.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 interface SpinnerProps {
-  size?: "sm" | "md" | "xs" | "lg";
+  size?: "sm" | "md" | "xs" | "lg" | "xl";
   variant?: "danger" | "";
   className?: string;
 }
@@ -9,12 +9,13 @@ interface SpinnerProps {
 const sizeToClass = {
   xs: "h-4 w-4",
   sm: "h-6 w-6",
-  md: "h-10 w-10",
-  lg: "h-16 w-16",
+  md: "h-8 w-8",
+  lg: "h-10 w-10",
+  xl: "h-16 w-16",
 };
 
 const Spinner: React.FC<SpinnerProps> = ({
-  size = "md",
+  size = "lg",
   variant = "",
   className = "",
 }) => (

--- a/frontend2/src/components/Table.tsx
+++ b/frontend2/src/components/Table.tsx
@@ -74,7 +74,7 @@ function Table<T>({
       </table>
       {loading && (
         <div className="flex h-64 w-full flex-row items-center justify-center">
-          <Spinner size="lg" />
+          <Spinner size="xl" />
         </div>
       )}
       <div className="mx-10 text-center">{bottomElement}</div>

--- a/frontend2/src/components/elements/DescriptiveCheckbox.tsx
+++ b/frontend2/src/components/elements/DescriptiveCheckbox.tsx
@@ -1,24 +1,32 @@
 import React from "react";
 import Icon from "./Icon";
 import { Switch } from "@headlessui/react";
+import Spinner from "../Spinner";
+
+export const enum CheckboxState {
+  CHECKED,
+  UNCHECKED,
+  LOADING,
+}
 
 interface DescriptiveCheckboxProps {
-  checked: boolean;
+  status: CheckboxState;
   onChange: (checked: boolean) => void;
   title: string;
   description: string;
 }
 
 const DescriptiveCheckbox: React.FC<DescriptiveCheckboxProps> = ({
-  checked,
+  status,
   onChange,
   title,
   description,
 }) => {
   return (
     <Switch
-      checked={checked}
+      checked={status === CheckboxState.CHECKED}
       onChange={onChange}
+      disabled={status === CheckboxState.LOADING}
       className={`flex w-full
       flex-row items-center justify-between gap-3 rounded-lg px-6 py-4 shadow ring-2 ring-inset
        ring-cyan-600/20 transition-all ui-checked:bg-cyan-900/80 ui-checked:ring-0`}
@@ -29,16 +37,23 @@ const DescriptiveCheckbox: React.FC<DescriptiveCheckboxProps> = ({
           {description}
         </div>
       </div>
-      <div
-        className="rounded-full p-1.5 ring-2 ring-inset ring-cyan-600/20 transition-all
-       ui-checked:bg-cyan-500/50 ui-checked:ring-0"
-      >
-        <Icon
-          name="check"
-          size="sm"
-          className={`text-cyan-100 opacity-0 ui-checked:opacity-100`}
-        />
-      </div>
+
+      {status === CheckboxState.LOADING ? (
+        <div>
+          <Spinner size="md" />
+        </div>
+      ) : (
+        <div
+          className="rounded-full p-1.5 ring-2 ring-inset ring-cyan-600/20 transition-all
+      ui-checked:bg-cyan-500/50 ui-checked:ring-0"
+        >
+          <Icon
+            name="check"
+            size="sm"
+            className={`text-cyan-100 opacity-0 ui-checked:opacity-100`}
+          />
+        </div>
+      )}
     </Switch>
   );
 };

--- a/frontend2/src/components/team/EligibilitySettings.tsx
+++ b/frontend2/src/components/team/EligibilitySettings.tsx
@@ -10,6 +10,7 @@ import DescriptiveCheckbox, {
 import { useEpisode, useEpisodeId } from "../../contexts/EpisodeContext";
 import { isPresent } from "../../utils/utilTypes";
 import { updateTeamPartial } from "../../utils/api/team";
+import { isEqual } from "lodash";
 
 export function determineCheckboxState(
   inDesired: boolean,
@@ -40,9 +41,8 @@ const EligibilitySettings: React.FC = () => {
   useEffect(() => {
     // if actual team eligibility hasn't loaded yet or the desired/actual are identical
     if (
-      (!isPresent(desiredEligibility) ||
-        desiredEligibility === team?.profile?.eligible_for) ??
-      []
+      !isPresent(desiredEligibility) ||
+      isEqual(desiredEligibility, team?.profile?.eligible_for)
     ) {
       return;
     }
@@ -56,10 +56,12 @@ const EligibilitySettings: React.FC = () => {
       if (isActive && isPresent(newProfile) && isPresent(team)) {
         // only update the eligibility of the team profile to avoid race conditions
         // with other team profile updaters on this page
-        newProfile.eligible_for = updatedTeam.profile?.eligible_for;
         refreshTeam({
           ...team,
-          profile: newProfile,
+          profile: {
+            ...newProfile,
+            eligible_for: updatedTeam.profile?.eligible_for,
+          },
         });
       }
     };
@@ -74,7 +76,7 @@ const EligibilitySettings: React.FC = () => {
     !isPresent(team) ||
     !isPresent(episode)
   ) {
-    return null;
+    return "Error: You're not in a team!";
   }
   return (
     <SectionCard title="Eligibility">

--- a/frontend2/src/components/team/EligibilitySettings.tsx
+++ b/frontend2/src/components/team/EligibilitySettings.tsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useState } from "react";
+import {
+  useCurrentTeam,
+  TeamStateEnum,
+} from "../../contexts/CurrentTeamContext";
+import SectionCard from "../SectionCard";
+import DescriptiveCheckbox, {
+  CheckboxState,
+} from "../elements/DescriptiveCheckbox";
+import { useEpisode, useEpisodeId } from "../../contexts/EpisodeContext";
+import { isPresent } from "../../utils/utilTypes";
+import { updateTeamPartial } from "../../utils/api/team";
+
+export function determineCheckboxState(
+  inDesired: boolean,
+  inActual: boolean,
+): CheckboxState {
+  if (inDesired && inActual) {
+    return CheckboxState.CHECKED;
+  } else if (!inDesired && !inActual) {
+    return CheckboxState.UNCHECKED;
+  } else {
+    return CheckboxState.LOADING;
+  }
+}
+
+// This component should only be used when there is a logged in user with a team.
+const EligibilitySettings: React.FC = () => {
+  const { team, teamState, refreshTeam } = useCurrentTeam();
+  const episode = useEpisode();
+  const { episodeId } = useEpisodeId();
+  // the desired state according to what the user has clicked on the page
+  const [desiredEligibility, setDesiredEligibility] = useState<
+    number[] | undefined
+  >();
+  useEffect(() => {
+    setDesiredEligibility(team?.profile?.eligible_for);
+  }, [team?.profile?.eligible_for]);
+
+  useEffect(() => {
+    // if actual team eligibility hasn't loaded yet or the desired/actual are identical
+    if (
+      (!isPresent(desiredEligibility) ||
+        desiredEligibility === team?.profile?.eligible_for) ??
+      []
+    ) {
+      return;
+    }
+
+    let isActive = true;
+    const update = async (): Promise<void> => {
+      const updatedTeam = await updateTeamPartial(episodeId, {
+        eligible_for: desiredEligibility,
+      });
+      const newProfile = team?.profile;
+      if (isActive && isPresent(newProfile) && isPresent(team)) {
+        // only update the eligibility of the team profile to avoid race conditions
+        // with other team profile updaters on this page
+        newProfile.eligible_for = updatedTeam.profile?.eligible_for;
+        refreshTeam({
+          ...team,
+          profile: newProfile,
+        });
+      }
+    };
+    void update();
+    return () => {
+      isActive = false;
+    };
+  }, [desiredEligibility, episodeId]);
+
+  if (
+    teamState !== TeamStateEnum.IN_TEAM ||
+    !isPresent(team) ||
+    !isPresent(episode)
+  ) {
+    return null;
+  }
+  return (
+    <SectionCard title="Eligibility">
+      <div className="flex flex-col gap-4 2xl:flex-row">
+        <div className="2xl:w-60">
+          <p className="text-gray-700">
+            Check the box(es) that apply to <i>all</i> members of your team.
+          </p>
+          <p className="text-gray-700">
+            This determines which tournaments and prizes your team is eligible
+            for.
+          </p>
+        </div>
+        <div className="flex flex-1 flex-col gap-2">
+          {isPresent(desiredEligibility) &&
+            episode.eligibility_criteria.map((criterion) => {
+              return (
+                <DescriptiveCheckbox
+                  key={criterion.id}
+                  status={determineCheckboxState(
+                    desiredEligibility.includes(criterion.id),
+                    (team.profile?.eligible_for ?? []).includes(criterion.id),
+                  )}
+                  onChange={(checked) => {
+                    if (checked && !desiredEligibility.includes(criterion.id)) {
+                      setDesiredEligibility([
+                        ...desiredEligibility,
+                        criterion.id,
+                      ]);
+                    } else if (!checked) {
+                      setDesiredEligibility(
+                        desiredEligibility.filter(
+                          (item) => item !== criterion.id,
+                        ),
+                      );
+                    }
+                  }}
+                  title={`${criterion.title} ${criterion.icon}`}
+                  description={criterion.description}
+                />
+              );
+            })}
+        </div>
+      </div>
+    </SectionCard>
+  );
+};
+
+export default EligibilitySettings;

--- a/frontend2/src/components/team/ScrimmageSettings.tsx
+++ b/frontend2/src/components/team/ScrimmageSettings.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from "react";
+import {
+  useCurrentTeam,
+  TeamStateEnum,
+} from "../../contexts/CurrentTeamContext";
+import SectionCard from "../SectionCard";
+import DescriptiveCheckbox from "../elements/DescriptiveCheckbox";
+import { useEpisode, useEpisodeId } from "../../contexts/EpisodeContext";
+import { isPresent } from "../../utils/utilTypes";
+import { updateTeamPartial } from "../../utils/api/team";
+import { determineCheckboxState } from "./EligibilitySettings";
+
+// This component should only be used when there is a logged in user with a team.
+const ScrimmageSettings: React.FC = () => {
+  const { team, teamState, refreshTeam } = useCurrentTeam();
+  const episode = useEpisode();
+  const { episodeId } = useEpisodeId();
+  // true when the team has accept on, undefined when team's data hasn't loaded
+  const [ranked, setRanked] = useState<boolean | undefined>(undefined);
+  const [unranked, setUnranked] = useState<boolean | undefined>(undefined);
+
+  useEffect(() => {
+    // update with most current status
+    const autoRanked = team?.profile?.auto_accept_ranked;
+    if (isPresent(autoRanked)) {
+      setRanked(autoRanked);
+    }
+    const autoUnranked = team?.profile?.auto_accept_unranked;
+    if (isPresent(autoUnranked)) {
+      setUnranked(autoUnranked);
+    }
+  }, [team?.profile?.auto_accept_ranked, team?.profile?.auto_accept_unranked]);
+
+  useEffect(() => {
+    // make API calls to update only if necessary
+    if (
+      !isPresent(ranked) ||
+      !isPresent(unranked) ||
+      (team?.profile?.auto_accept_ranked === ranked &&
+        team.profile.auto_accept_unranked === unranked)
+    ) {
+      return;
+    }
+
+    let isActive = true;
+    const update = async (): Promise<void> => {
+      const updatedTeam = await updateTeamPartial(episodeId, {
+        auto_accept_ranked: ranked,
+        auto_accept_unranked: unranked,
+      });
+      const newProfile = team?.profile;
+      if (isActive && isPresent(newProfile) && isPresent(team)) {
+        // only update the ranked / unranked of the team profile to avoid
+        // race conditions with other team profile updaters on this page
+        newProfile.auto_accept_ranked = updatedTeam.profile?.auto_accept_ranked;
+        newProfile.auto_accept_unranked =
+          updatedTeam.profile?.auto_accept_unranked;
+        refreshTeam({
+          ...team,
+          profile: newProfile,
+        });
+      }
+    };
+    void update();
+    return () => {
+      isActive = false;
+    };
+  }, [ranked, unranked, episodeId]);
+
+  if (
+    teamState !== TeamStateEnum.IN_TEAM ||
+    !isPresent(team) ||
+    !isPresent(episode) ||
+    !isPresent(ranked) ||
+    !isPresent(unranked)
+  ) {
+    return null;
+  }
+  return (
+    <SectionCard title="Scrimmaging">
+      <div className="flex flex-col gap-3 2xl:flex-row">
+        <div className="text-green-600 2xl:w-60">
+          <p className="text-gray-700">
+            Choose how you want to handle incoming scrimmage requests from other
+            players.
+          </p>
+        </div>
+        <div className="flex flex-1 flex-col gap-2">
+          <DescriptiveCheckbox
+            status={determineCheckboxState(
+              ranked,
+              team.profile?.auto_accept_ranked ?? false,
+            )}
+            onChange={(checked) => {
+              setRanked(checked);
+            }}
+            title="Auto-accept ranked scrimmages"
+            description="When enabled, your team will automatically accept
+                  ranked scrimmage requests. Ranked scrimmages affect your ELO rating."
+          />
+          <DescriptiveCheckbox
+            status={determineCheckboxState(
+              unranked,
+              team.profile?.auto_accept_unranked ?? true,
+            )}
+            onChange={(checked) => {
+              setUnranked(checked);
+            }}
+            title="Auto-accept unranked scrimmages"
+            description="When enabled, your team will automatically accept
+                  unranked scrimmage requests. Unranked scrimmages do not affect your ELO rating."
+          />
+        </div>
+      </div>
+    </SectionCard>
+  );
+};
+
+export default ScrimmageSettings;

--- a/frontend2/src/views/MyTeam.tsx
+++ b/frontend2/src/views/MyTeam.tsx
@@ -6,13 +6,13 @@ import TextArea from "../components/elements/TextArea";
 import { TeamStateEnum, useCurrentTeam } from "../contexts/CurrentTeamContext";
 import Button from "../components/elements/Button";
 import MemberList from "../components/team/MemberList";
-import DescriptiveCheckbox from "../components/elements/DescriptiveCheckbox";
 import JoinTeam from "../components/JoinTeam";
 import Modal from "../components/Modal";
+import EligibilitySettings from "../components/team/EligibilitySettings";
+import ScrimmageSettings from "../components/team/ScrimmageSettings";
 
 const MyTeam: React.FC = () => {
   const { team, teamState, leaveMyTeam } = useCurrentTeam();
-  const [checked, setChecked] = useState<boolean>(false);
   const [isLeaveModalOpen, setIsLeaveModalOpen] = useState<boolean>(false);
   const [isLeaveTeamPending, setIsLeaveTeamPending] = useState<boolean>(false);
   const membersList = useMemo(() => {
@@ -68,90 +68,15 @@ const MyTeam: React.FC = () => {
           <SectionCard className="shrink xl:hidden" title="Members">
             {membersList}
           </SectionCard>
-          <SectionCard title="Eligibility">
-            <div className="flex flex-col gap-4 2xl:flex-row">
-              <div className="2xl:w-60">
-                <p className="text-gray-700">
-                  Check the box(es) that apply to <i>all</i> members of your
-                  team.
-                </p>
-                <p className="text-gray-700">
-                  This determines which tournaments and prizes your team is
-                  eligible for.
-                </p>
-              </div>
-              <div className="flex flex-1 flex-col gap-2">
-                <DescriptiveCheckbox
-                  checked={checked}
-                  onChange={(checked) => {
-                    setChecked(checked);
-                  }}
-                  title="Student"
-                  description="Here's a description of what a student is"
-                />
-                <DescriptiveCheckbox
-                  checked={checked}
-                  onChange={(checked) => {
-                    setChecked(checked);
-                  }}
-                  title="US Student"
-                  description="Here's a description of what a US student is"
-                />
-                <DescriptiveCheckbox
-                  checked={checked}
-                  onChange={(checked) => {
-                    setChecked(checked);
-                  }}
-                  title="High school student"
-                  description="These descriptions and titles should be loaded dynamically."
-                />
-                <DescriptiveCheckbox
-                  checked={checked}
-                  onChange={(checked) => {
-                    setChecked(checked);
-                  }}
-                  title="Newbie"
-                  description="These descriptions and titles should be loaded dynamically. I think this is MIT newbie? we might want to rename this criteria"
-                />
-              </div>
-            </div>
-          </SectionCard>
-          <SectionCard title="Scrimmaging">
-            <div className="flex flex-col gap-3 2xl:flex-row">
-              <div className="text-green-600 2xl:w-60">
-                <p className="text-gray-700">
-                  Choose how you want to handle incoming scrimmage requests from
-                  other players.
-                </p>
-              </div>
-              <div className="flex flex-1 flex-col gap-2">
-                <DescriptiveCheckbox
-                  checked={checked}
-                  onChange={(checked) => {
-                    setChecked(checked);
-                  }}
-                  title="Auto-accept ranked scrimmages"
-                  description="When enabled, your team will automatically accept
-                  ranked scrimmage requests. Ranked scrimmages affect your ELO rating."
-                />
-                <DescriptiveCheckbox
-                  checked={checked}
-                  onChange={(checked) => {
-                    setChecked(checked);
-                  }}
-                  title="Auto-accept unranked scrimmages"
-                  description="When enabled, your team will automatically accept
-                  unranked scrimmage requests. Unranked scrimmages do not affect your ELO rating."
-                />
-              </div>
-            </div>
-          </SectionCard>
+          <EligibilitySettings />
+          <ScrimmageSettings />
         </div>
         {/* The members list that displays to the right side when on a big screen. */}
         <SectionCard className="hidden w-1/3 shrink xl:block" title="Members">
           {membersList}
         </SectionCard>
       </div>
+      {/* The confirmation modal that pops up when a user clicks "Leave Team" */}
       <Modal
         isOpen={isLeaveModalOpen}
         closeModal={() => {


### PR DESCRIPTION
Make the big checkboxes for changing eligibility / scrim settings work.
When reviewing / testing, please especially watch out for race conditions. I think I've addressed all potential race conditions, but would appreciate another check.

Testing plan:
* Be on a team. Click a checkbox. The spinner should appear in the checkbox until the request is resolved, and the checkbox should be set to the opposite of what it was before. 
* The checkbox should not be clickable while it is in the loading state.
* Clicking multiple checkboxes fast should not lead to inconsistent behavior

Merge after https://github.com/battlecode/galaxy/pull/699

Example: 
![image](https://github.com/battlecode/galaxy/assets/40174697/38e0a1d1-82de-419f-b976-07c485b8e5b2)
