### PR TITLE
enable tourney match lookup by external id 

### DIFF
--- a/backend/siarnaq/api/compete/serializers.py
+++ b/backend/siarnaq/api/compete/serializers.py
@@ -19,6 +19,7 @@ from siarnaq.api.compete.models import (
     Submission,
 )
 from siarnaq.api.episodes.models import Map, ReleaseStatus
+from siarnaq.api.episodes.serializers import TournamentRoundSerializer
 from siarnaq.api.teams.models import Team, TeamStatus
 from siarnaq.api.teams.serializers import RatingField
 
@@ -238,6 +239,7 @@ class MatchSerializer(serializers.ModelSerializer):
     participants = MatchParticipantSerializer(many=True)
     maps = serializers.SerializerMethodField()
     replay_url = serializers.SerializerMethodField()
+    tournament_round = TournamentRoundSerializer(required=False, allow_null=True)
 
     class Meta:
         model = Match

--- a/backend/siarnaq/api/compete/test_views.py
+++ b/backend/siarnaq/api/compete/test_views.py
@@ -1096,6 +1096,9 @@ class MatchViewSetTestCase(APITestCase):
         self.m_private_results = self.helper_create_tournament_match(
             self.r_private_results
         )
+        # extra tournament match for regression test (using external ID
+        # shouldn't return all matches)
+        self.helper_create_tournament_match(self.r_public_results)
 
     # Partitions for: tournament.
     # match tournament: public, private

--- a/backend/siarnaq/api/compete/test_views.py
+++ b/backend/siarnaq/api/compete/test_views.py
@@ -1,6 +1,5 @@
 import io
 import random
-import sys
 from datetime import timedelta
 from unittest.mock import mock_open, patch
 
@@ -393,7 +392,6 @@ class MatchSerializerTestCase(TestCase):
         )
         match.maps.add(self.map)
         data = serializer.to_representation(match)
-        print(data, file=sys.stderr)
         self.assertEqual(
             data,
             {

--- a/backend/siarnaq/api/compete/test_views.py
+++ b/backend/siarnaq/api/compete/test_views.py
@@ -1112,6 +1112,7 @@ class MatchViewSetTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 3)
+        self.assertEqual(len(response.json()["results"][0]["participants"]), 2)
 
     def test_not_public_bad_external_id(self):
         """tournament is private, wrong external id"""

--- a/backend/siarnaq/api/compete/test_views.py
+++ b/backend/siarnaq/api/compete/test_views.py
@@ -1,5 +1,6 @@
 import io
 import random
+import sys
 from datetime import timedelta
 from unittest.mock import mock_open, patch
 
@@ -321,15 +322,17 @@ class MatchSerializerTestCase(TestCase):
         self.r_hidden = TournamentRound.objects.create(
             tournament=tournament, release_status=ReleaseStatus.HIDDEN, display_order=0
         )
+        self.r_hidden.maps.set([self.map])
         self.r_participants = TournamentRound.objects.create(
             tournament=tournament,
             release_status=ReleaseStatus.PARTICIPANTS,
             display_order=1,
         )
+        self.r_participants.maps.set([self.map])
         self.r_results = TournamentRound.objects.create(
             tournament=tournament, release_status=ReleaseStatus.RESULTS, display_order=2
         )
-
+        self.r_results.maps.set([self.map])
         self.users, self.teams, self.submissions = [], [], []
         for i in range(4):
             u = User.objects.create_user(
@@ -390,13 +393,21 @@ class MatchSerializerTestCase(TestCase):
         )
         match.maps.add(self.map)
         data = serializer.to_representation(match)
+        print(data, file=sys.stderr)
         self.assertEqual(
             data,
             {
                 "id": match.pk,
                 "status": str(match.status),
                 "episode": match.episode.pk,
-                "tournament_round": self.r_hidden.pk,
+                "tournament_round": {
+                    "id": self.r_hidden.pk,
+                    "tournament": self.r_hidden.tournament.pk,
+                    "external_id": self.r_hidden.external_id,
+                    "name": self.r_hidden.name,
+                    "maps": None,
+                    "release_status": self.r_hidden.release_status,
+                },
                 "participants": [
                     {
                         "team": red.team.pk,
@@ -538,7 +549,14 @@ class MatchSerializerTestCase(TestCase):
                 "id": match.pk,
                 "status": str(match.status),
                 "episode": match.episode.pk,
-                "tournament_round": self.r_results.pk,
+                "tournament_round": {
+                    "id": self.r_results.pk,
+                    "tournament": self.r_results.tournament.pk,
+                    "external_id": self.r_results.external_id,
+                    "name": self.r_results.name,
+                    "maps": [self.map.pk],
+                    "release_status": self.r_results.release_status,
+                },
                 "participants": [
                     {
                         "team": red.team.pk,
@@ -609,7 +627,14 @@ class MatchSerializerTestCase(TestCase):
                 "id": match.pk,
                 "status": str(match.status),
                 "episode": match.episode.pk,
-                "tournament_round": self.r_participants.pk,
+                "tournament_round": {
+                    "id": self.r_participants.pk,
+                    "tournament": self.r_participants.tournament.pk,
+                    "external_id": self.r_participants.external_id,
+                    "name": self.r_participants.name,
+                    "maps": None,
+                    "release_status": self.r_participants.release_status,
+                },
                 "participants": [
                     {
                         "team": red.team.pk,
@@ -680,7 +705,14 @@ class MatchSerializerTestCase(TestCase):
                 "id": match.pk,
                 "status": str(match.status),
                 "episode": match.episode.pk,
-                "tournament_round": self.r_hidden.pk,
+                "tournament_round": {
+                    "id": self.r_hidden.pk,
+                    "tournament": self.r_hidden.tournament.pk,
+                    "external_id": self.r_hidden.external_id,
+                    "name": self.r_hidden.name,
+                    "maps": None,
+                    "release_status": self.r_hidden.release_status,
+                },
                 "participants": None,
                 "maps": None,
                 "alternate_order": match.alternate_order,

--- a/backend/siarnaq/api/compete/views.py
+++ b/backend/siarnaq/api/compete/views.py
@@ -274,8 +274,6 @@ class MatchViewSet(
         if external_id_private is not None:
             tournaments = Tournament.objects.visible_to_user(is_staff=True)
             tournaments = tournaments.filter(external_id_private=external_id_private)
-            if tournaments.count() != 1:
-                return Response(None, status=status.HTTP_404_NOT_FOUND)
         else:
             # Filter tournament as requested
             tournaments = Tournament.objects.visible_to_user(
@@ -287,7 +285,8 @@ class MatchViewSet(
             queryset = self.get_queryset().filter(
                 tournament_round__tournament__in=Subquery(tournaments.values("pk"))
             )
-
+        if tournaments.count() != 1:
+            return Response(None, status=status.HTTP_404_NOT_FOUND)
         # Filter rounds as requested
         round_id = parse_int(self.request.query_params.get("round_id"))
         if round_id is not None:
@@ -354,7 +353,7 @@ class MatchViewSet(
             status.HTTP_204_NO_CONTENT: OpenApiResponse(
                 description="No ranked matches found."
             ),
-            status.HTTP_200_OK: HistoricalRatingSerializer(),
+            status.HTTP_200_OK: HistoricalRatingSerializer(many=True),
         },
     )
     @action(

--- a/backend/siarnaq/api/compete/views.py
+++ b/backend/siarnaq/api/compete/views.py
@@ -244,6 +244,11 @@ class MatchViewSet(
                 description="A tournament to filter for.",
             ),
             OpenApiParameter(
+                name="external_id_private",
+                type=str,
+                description="A private id to filter for.",
+            ),
+            OpenApiParameter(
                 name="round_id",
                 type=int,
                 description="A tournament round to filter for.",

--- a/backend/siarnaq/api/compete/views.py
+++ b/backend/siarnaq/api/compete/views.py
@@ -282,11 +282,11 @@ class MatchViewSet(
             tournament_id = self.request.query_params.get("tournament_id")
             if tournament_id is not None:
                 tournaments = tournaments.filter(pk=tournament_id)
-            queryset = self.get_queryset().filter(
-                tournament_round__tournament__in=Subquery(tournaments.values("pk"))
-            )
         if tournaments.count() != 1:
             return Response(None, status=status.HTTP_404_NOT_FOUND)
+        queryset = self.get_queryset().filter(
+            tournament_round__tournament__in=Subquery(tournaments.values("pk"))
+        )
         # Filter rounds as requested
         round_id = parse_int(self.request.query_params.get("round_id"))
         if round_id is not None:

--- a/backend/siarnaq/api/compete/views.py
+++ b/backend/siarnaq/api/compete/views.py
@@ -303,6 +303,7 @@ class MatchViewSet(
         queryset = self.get_queryset().filter(
             tournament_round__tournament__in=Subquery(tournaments.values("pk"))
         )
+
         # Filter rounds as requested
         round_id = parse_int(self.request.query_params.get("round_id"))
         if round_id is not None:
@@ -369,7 +370,7 @@ class MatchViewSet(
             status.HTTP_204_NO_CONTENT: OpenApiResponse(
                 description="No ranked matches found."
             ),
-            status.HTTP_200_OK: HistoricalRatingSerializer(many=True),
+            status.HTTP_200_OK: HistoricalRatingSerializer(),
         },
     )
     @action(


### PR DESCRIPTION
Enables lookup of tournament matches by external id. Needed for client tourney display
Updates/adds tests to cover external id query param for /tournament in matchviewset

API endpoint:  `api.battlecode.org/api/compete/bc23/match/tournament/`
Example parameters for client:
  `http://localhost:8000/api/compete/bc23/match/tournament/?external_id_private=privatechallongid`

Example response
```json
{
  "count": 21,
  "next": "http://localhost:8000/api/compete/bc23/match/tournament/?external_id_private=<private id here>&page=2&tournament_id=bc23tt29",
  "previous": null,
  "results": [
    {
      "id": 203,
      "status": "OK!",
      "episode": "bc23",
      "tournament_round": {
        "id": 262,
        "tournament": "bc23tt28",
        "external_id": 6,
        "name": "Round 6 (Winners)",
        "maps": [
          3
        ],
        "release_status": 2
      },
      "participants": [
        {
          "team": 35,
          "teamname": "profile",
          "submission": 141,
          "match": 203,
          "player_index": 0,
          "score": 0,
          "rating": null,
          "old_rating": 0
        },
        {
          "team": 48,
          "teamname": "aefW",
          "submission": 139,
          "match": 203,
          "player_index": 1,
          "score": 1,
          "rating": null,
          "old_rating": 0
        }
      ],
      "maps": [
        "DefaultMap"
      ],
      "alternate_order": true,
      "created": "2023-01-26T19:26:40.604934-05:00",
      "is_ranked": false,
      "replay_url": "https://storage.googleapis.com/mitbattlecode-staging-secure/episode/bc23/replays/e3572232-990b-48ee-b051-c2dbf4b14d73.bc23"
    },
  ...
  ]
}
```