### PR TITLE
fix multiepisode strategy report bug

### DIFF
--- a/backend/siarnaq/api/teams/views.py
+++ b/backend/siarnaq/api/teams/views.py
@@ -226,7 +226,7 @@ class ClassRequirementViewSet(viewsets.ReadOnlyModelViewSet):
     )
     def report(self, request, pk=None, *, episode_id):
         """Retrieve or update team strategy report"""
-        team = Team.objects.filter(members=request.user).get()
+        team = Team.objects.filter(episode=episode_id, members=request.user).get()
         profile = team.profile
         match request.method.lower():
             case "get":


### PR DESCRIPTION
Fixes a bug in the team report endpoints where we didn't filter for episode

Tested locally with a user on 2 teams. `GET /api/team/{episode_id}/requirement/report/` returned 404 which is expected (previously returned 500)