### PR TITLE
change execute machines to t2d-standard-16

### DIFF
--- a/deploy/.terraform.lock.hcl
+++ b/deploy/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/google" {
   version     = "4.49.0"
   constraints = ">= 3.53.0, < 5.0.0"
   hashes = [
+    "h1:DOYre+TiAErDprRnWy3HB1skET0rNtTqVT6HxNtY11M=",
     "h1:VwkL9Fad+rukROzUBsY2sEojy/6+quKJewXfmac3tI8=",
     "zh:06759e2760d4c462d1c29ffae91f14be05b478570804c38fdac343bf4e40362e",
     "zh:3728742e19d8df05954c48d09e0ed88943f940c18d200f0e872028d576567d63",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   constraints = ">= 3.53.0, < 5.0.0"
   hashes = [
     "h1:/Z9B/HivPhS6JeMo3Oho/UVUNkOgiVsd0kmPoOUY8YI=",
+    "h1:RTBBszooJGdqyPJE0pQGVWwCslTAEwSCQGLIRTDuPrc=",
     "zh:03f7d936d581dff14bb963b05a444a9c0b1fd41d26375ce27918fb7c45614689",
     "zh:3c64e80aa346a812de3ff0b351c3d50e7fe1c44747426bfd2087bd1a887eb45b",
     "zh:3fe17786069603a212feacc2f1c816b0f491dcff1a6d8c5385ecbdee993d35a0",
@@ -44,6 +46,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.1"
   hashes = [
+    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
     "h1:tSj1mL6OQ8ILGqR2mDu7OYYYWf+hoir0pf9KAQ8IzO8=",
     "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
     "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",

--- a/deploy/galaxy/main.tf
+++ b/deploy/galaxy/main.tf
@@ -232,12 +232,12 @@ module "saturn_execute" {
   storage_releases_name  = var.storage_releases_name
 
   secret_id   = google_secret_manager_secret.saturn.secret_id
-  parallelism = 2
+  parallelism = 12
 
   network_vpc_id = google_compute_network.this.id
   subnetwork_ip_cidr = "172.17.0.0/16"
 
-  machine_type = "t2d-standard-4"
+  machine_type = "t2d-standard-16"
   image        = var.saturn_image
 
   max_instances = var.max_execute_instances

--- a/deploy/galaxy/main.tf
+++ b/deploy/galaxy/main.tf
@@ -242,7 +242,7 @@ module "saturn_execute" {
 
   max_instances = var.max_execute_instances
   min_instances = var.min_execute_instances
-  load_ratio    = 5
+  load_ratio    = 50
 }
 
 resource "google_cloudbuild_trigger" "saturn" {

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -51,7 +51,7 @@ module "production" {
   min_compile_instances = 0
   max_compile_instances = 5
   min_execute_instances = 0
-  max_execute_instances = 50
+  max_execute_instances = 10
   saturn_secrets        = var.saturn_secrets_production
   storage_releases_name = module.releases.storage_bucket_name
 


### PR DESCRIPTION
change execute machines from `t2d-standard-4` to `t2d-standard-16`
increase execute parallelism from 2 to 12 (run 12 games / machine instead of 2 games/machine)
decrease max number of execute instances from 50 to 10
increase load ratio to 50 (50 games in queue / machine)

reasoning (jerry)
* scale up delay is less heinous
* scale down is less likely to kill a half-complete game
* you can get away with allocating less memory per game because most games are low-memory, and worst-case games aren’t frequent