### PR TITLE
Better options for creating challonge tournaments

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -11,8 +11,8 @@ is the backend of Siarnaq, written in Django.
    `db.sqlite3`, which contains a toy database for testing. You should not commit this.
 1. Run `./manage.py runserver` to turn on the server!
 
-While developing, you may find the `api/specs/swagger-ui` endpoint userful for viewing
-and querying the avaiable API.
+While developing, you may find the `api/specs/swagger-ui` endpoint useful for viewing
+and querying the available API. To authenticate to use this, log into some page that would use the same environment (such as the frontend homepage or admin page in the same environment), then refresh the page. Get the value of the `access` cookie used in the _header_ of the HTTP request (usually in the dev tools or network tab). Copy it, making sure not to include any spaces or punctuation from the beginning or end. Then on the `swagger-ui` endpoint, click `Authenticate` at the top, and enter the copied value there.
 
 If you ever get your database into a really broken state, just delete `db.sqlite3`, and
 start again.

--- a/backend/siarnaq/bracket/challonge.py
+++ b/backend/siarnaq/bracket/challonge.py
@@ -59,6 +59,7 @@ def create_tournament(tournament: Tournament, *, is_private: bool):
                 "tournament_type": challonge_type,
                 "private": is_private,
                 "url": challonge_id,
+                "game_name": "Battlecode",
                 "match_options": {"accept_attachments": True},
             },
         }

--- a/backend/siarnaq/bracket/challonge.py
+++ b/backend/siarnaq/bracket/challonge.py
@@ -60,7 +60,9 @@ def create_tournament(tournament: Tournament, *, is_private: bool):
                 "private": is_private,
                 "url": challonge_id,
                 "game_name": "Battlecode",
-                "match_options": {"accept_attachments": True},
+                "match_options": {
+                    "accept_attachments": True
+                },  # need to add attachments(replay url) manually
             },
         }
     }

--- a/backend/siarnaq/bracket/challonge.py
+++ b/backend/siarnaq/bracket/challonge.py
@@ -59,6 +59,7 @@ def create_tournament(tournament: Tournament, *, is_private: bool):
                 "tournament_type": challonge_type,
                 "private": is_private,
                 "url": challonge_id,
+                "match_options": {"accept_attachments": True},
             },
         }
     }


### PR DESCRIPTION
]Attachments change: To actually _let_ us add attachments (in our case, replay links). Attaching via API doesn't work but at least you can do manually
Game name: This is required not by the API v2 but by the tournament settings _website_. (Either they do frontend validation or use v1 of API.) So if you ever change the settings manually via website, you have to go back and add the game name, which gets really painful.... Also all our other tournaments have game name anyways, so might as well keep that around.

Also includes some dev notes