### PR TITLE
log tracebacks for tasks, log errors properly

### DIFF
--- a/saturn/pkg/saturn/task.go
+++ b/saturn/pkg/saturn/task.go
@@ -95,7 +95,7 @@ func (t *Task) Run(ctx context.Context, r Reporter) (err error) {
 		if err != nil {
 			log.Ctx(ctx).Error().Msg(string(debug.Stack()))
 		}
-		if errReport = t.FinalizeReport(ctx, r); errReport != nil {
+		if errReport := t.FinalizeReport(ctx, r); errReport != nil {
 			err = fmt.Errorf("%v, t.FinalizeReport: %v", err, errReport)
 		}
 		if t.status.Retryable() {

--- a/saturn/pkg/saturn/task.go
+++ b/saturn/pkg/saturn/task.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -92,10 +93,10 @@ func (t *Task) Run(ctx context.Context, r Reporter) (err error) {
 			panic(r)
 		}
 		if err != nil {
-			// TODO: log a traceback
+			log.Ctx(ctx).Error().Msg(string(debug.Stack()))
 		}
-		if err = t.FinalizeReport(ctx, r); err != nil {
-			err = fmt.Errorf("t.FinalizeReport: %v", err)
+		if errReport = t.FinalizeReport(ctx, r); errReport != nil {
+			err = fmt.Errorf("%v, t.FinalizeReport: %v", err, errReport)
 		}
 		if t.status.Retryable() {
 			err = fmt.Errorf("task not complete: %v", err)


### PR DESCRIPTION
If an error occurs while running a task, log a traceback.

This PR also fixes the bug where the error from running a task was overriden/deleted by the error from calling FinalizeReport, resulting in our logs not containing the error.

**Testing**: not sure how to test this locally