### PR TITLE
Routing Improvements

### DIFF
--- a/frontend2/src/App.tsx
+++ b/frontend2/src/App.tsx
@@ -20,7 +20,7 @@ import {
   type LoaderFunction,
 } from "react-router-dom";
 import { DEFAULT_EPISODE } from "./utils/constants";
-import NotFound from "./views/NotFound";
+import EpisodeNotFound from "./views/EpisodeNotFound";
 import Rankings from "./views/Rankings";
 import { CurrentUserProvider } from "./contexts/CurrentUserProvider";
 import PrivateRoute from "./components/PrivateRoute";
@@ -48,6 +48,7 @@ import { tournamentLoader } from "./api/loaders/tournamentLoader";
 import { homeLoader } from "./api/loaders/homeLoader";
 import ErrorBoundary from "./views/ErrorBoundary";
 import { searchTeamsFactory } from "api/team/teamFactories";
+import PageNotFound from "views/PageNotFound";
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
@@ -90,7 +91,9 @@ const episodeLoader: LoaderFunction = async ({ params }) => {
   // if the episode is not found, throw an error.
   const id = params.episodeId ?? "";
   if (id === "") {
-    throw new Error("Episode not found");
+    throw new ResponseError(
+      new Response("Episode not found.", { status: 404 }),
+    );
   }
 
   // Await the episode info so we can be sure that it exists.
@@ -102,7 +105,10 @@ const episodeLoader: LoaderFunction = async ({ params }) => {
 
   // Prefetch the top 10 ranked teams' rating histories.
   void queryClient.ensureQueryData({
-    queryKey: buildKey(searchTeamsFactory.queryKey, { episodeId: id, page: 1 }),
+    queryKey: buildKey(searchTeamsFactory.queryKey, {
+      episodeId: id,
+      page: 1,
+    }),
     queryFn: async () =>
       await searchTeamsFactory.queryFn(
         { episodeId: id, page: 1 },
@@ -143,7 +149,7 @@ const router = createBrowserRouter([
   // Pages that will contain the episode sidebar and navbar (excl. account page)
   {
     element: <EpisodeLayout />,
-    errorElement: <NotFound />,
+    errorElement: <EpisodeNotFound />,
     path: "/:episodeId",
     loader: episodeLoader,
     children: [
@@ -204,7 +210,7 @@ const router = createBrowserRouter([
       },
       {
         path: "*",
-        element: <NotFound />,
+        element: <PageNotFound />,
       },
     ],
   },

--- a/frontend2/src/App.tsx
+++ b/frontend2/src/App.tsx
@@ -93,6 +93,13 @@ const episodeLoader: LoaderFunction = async ({ params }) => {
     throw new Error("Episode not found");
   }
 
+  // Await the episode info so we can be sure that it exists.
+  const episodeInfo = await queryClient.ensureQueryData({
+    queryKey: buildKey(episodeInfoFactory.queryKey, { id }),
+    queryFn: async () => await episodeInfoFactory.queryFn({ id }),
+    staleTime: Infinity,
+  });
+
   // Prefetch the top 10 ranked teams' rating histories.
   void queryClient.ensureQueryData({
     queryKey: buildKey(searchTeamsFactory.queryKey, { episodeId: id, page: 1 }),
@@ -104,12 +111,7 @@ const episodeLoader: LoaderFunction = async ({ params }) => {
       ),
   });
 
-  // Prefetch the episode info.
-  return await queryClient.ensureQueryData({
-    queryKey: buildKey(episodeInfoFactory.queryKey, { id }),
-    queryFn: async () => await episodeInfoFactory.queryFn({ id }),
-    staleTime: Infinity,
-  });
+  return episodeInfo;
 };
 
 const router = createBrowserRouter([

--- a/frontend2/src/components/EpisodeSwitcher.tsx
+++ b/frontend2/src/components/EpisodeSwitcher.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo, useState } from "react";
+import React, { Fragment, useMemo } from "react";
 import { Listbox, Transition } from "@headlessui/react";
 import Icon from "./elements/Icon";
 import { useEpisodeId } from "../contexts/EpisodeContext";

--- a/frontend2/src/components/EpisodeSwitcher.tsx
+++ b/frontend2/src/components/EpisodeSwitcher.tsx
@@ -1,27 +1,30 @@
-import React, { Fragment, useMemo } from "react";
+import React, { Fragment, useMemo, useState } from "react";
 import { Listbox, Transition } from "@headlessui/react";
 import Icon from "./elements/Icon";
 import { useEpisodeId } from "../contexts/EpisodeContext";
 import { isPresent } from "../utils/utilTypes";
 import { useNavigate } from "react-router-dom";
-import { useEpisodeList } from "../api/episode/useEpisode";
+import { useEpisodeInfo, useEpisodeList } from "../api/episode/useEpisode";
 import { useQueryClient } from "@tanstack/react-query";
-import toast from "react-hot-toast";
-import { episodeInfoFactory } from "../api/episode/episodeFactories";
-import { buildKey } from "../api/helpers";
+import Spinner from "./Spinner";
 
 const EpisodeSwitcher: React.FC = () => {
   const queryClient = useQueryClient();
   const { episodeId, setEpisodeId } = useEpisodeId();
-  const { data: episodeList } = useEpisodeList({ page: 1 }, queryClient);
+  const episodeList = useEpisodeList({ page: 1 }, queryClient);
+  const episodeInfo = useEpisodeInfo({ id: episodeId });
   const navigate = useNavigate();
   const idToName = useMemo(
     () =>
       new Map(
-        (episodeList?.results ?? []).map((ep) => [ep.name_short, ep.name_long]),
+        (episodeList?.data?.results ?? []).map((ep) => [
+          ep.name_short,
+          ep.name_long,
+        ]),
       ),
     [episodeList],
   );
+
   if (!isPresent(episodeList)) {
     return null;
   }
@@ -30,27 +33,24 @@ const EpisodeSwitcher: React.FC = () => {
       <Listbox
         value={episodeId}
         onChange={(newEpisodeId) => {
-          (async () =>
-            await queryClient.fetchQuery({
-              queryKey: buildKey(episodeInfoFactory.queryKey, {
-                id: newEpisodeId,
-              }),
-              queryFn: async () =>
-                await episodeInfoFactory.queryFn({ id: newEpisodeId }),
-            }))().catch((e) => toast.error((e as Error).message));
           setEpisodeId(newEpisodeId);
           navigate(`/${newEpisodeId}/home`);
         }}
       >
         <div className="relative">
           <Listbox.Button
-            className={`relative h-9 w-full truncate rounded-full bg-gray-900/80 py-1.5
+            className={`relative flex h-9 w-full flex-row items-center justify-center gap-3 truncate rounded-full bg-gray-900/80 py-1.5
             pl-3.5 pr-8 text-left text-gray-100 shadow-sm focus:outline-none
             sm:text-sm sm:leading-6`}
           >
             <span className="text-sm font-semibold">
               {idToName.get(episodeId)}
             </span>
+            {(episodeList.isLoading || episodeInfo.isLoading) && (
+              <div className="my-1 flex w-full justify-center">
+                <Spinner size="xs" />
+              </div>
+            )}
             <div
               className="absolute inset-y-0 right-0 mr-2 flex transform items-center
               transition duration-300 ui-open:rotate-180"
@@ -69,7 +69,7 @@ const EpisodeSwitcher: React.FC = () => {
               bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none
               sm:max-h-60 sm:text-sm"
             >
-              {episodeList?.results?.map((ep) => (
+              {episodeList?.data?.results?.map((ep) => (
                 <Listbox.Option
                   className="flex cursor-default flex-row justify-between py-1.5 pl-4 pr-2 ui-active:bg-cyan-100"
                   key={ep.name_short}

--- a/frontend2/src/views/EpisodeNotFound.tsx
+++ b/frontend2/src/views/EpisodeNotFound.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { DEFAULT_EPISODE } from "utils/constants";
+
+const EpisodeNotFound: React.FC = () => {
+  return (
+    <div className="flex h-full w-full flex-col overflow-auto p-6">
+      <p>
+        That episode was not found.{" "}
+        <Link to={`/${DEFAULT_EPISODE}/home`} className="hover:underline">
+          Go Home?
+        </Link>
+      </p>
+    </div>
+  );
+};
+
+export default EpisodeNotFound;

--- a/frontend2/src/views/Login.tsx
+++ b/frontend2/src/views/Login.tsx
@@ -75,7 +75,7 @@ const Login: React.FC = () => {
         <div>
           <hr />
           <div className="mt-3 flex flex-row justify-between text-sm text-cyan-600">
-            <Link to="/forgot_password">Forgot password?</Link>
+            <Link to="/password_forgot">Forgot password?</Link>
             <Link to={episodeId !== undefined ? `/${episodeId}/home` : "/"}>
               Back to home
             </Link>

--- a/frontend2/src/views/NotFound.tsx
+++ b/frontend2/src/views/NotFound.tsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const NotFound: React.FC = () => {
-  return <p>That page was not found.</p>;
-};
-
-export default NotFound;

--- a/frontend2/src/views/PageNotFound.tsx
+++ b/frontend2/src/views/PageNotFound.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { DEFAULT_EPISODE } from "utils/constants";
+
+const PageNotFound: React.FC = () => {
+  return (
+    <div className="flex h-full w-full flex-col overflow-auto p-6">
+      <p>
+        That page was not found.{" "}
+        <NavLink to={`/${DEFAULT_EPISODE}/home`} className="hover:underline">
+          Go Home?
+        </NavLink>
+      </p>
+    </div>
+  );
+};
+
+export default PageNotFound;


### PR DESCRIPTION
Fixes some routing insecurities and improves flow of control around episode switching.
 - [x] Episode info must be loaded before the home page renders 
  - [x] Await load episode info in the episodeLoader
  - [x] Indicate that the episode is loading in the episode switcher while it verifies that the episode exists
 - [x] If the episode info load fails, redirect to 404 not found page
 - [x] If the page load fails, redirect to 404 not found page
 - [x] Navigating to "localhost:3000" redirects to current episode home page

Closes #794 :rocket: