### PR TITLE
Nour/improving rating history performance

### DIFF
--- a/backend/siarnaq/api/compete/views.py
+++ b/backend/siarnaq/api/compete/views.py
@@ -4,8 +4,9 @@ from typing import Optional
 import google.cloud.storage as storage
 import structlog
 from django.conf import settings
+from django.contrib.postgres.aggregates import ArrayAgg
 from django.db import NotSupportedError, transaction
-from django.db.models import Exists, OuterRef, Q, Subquery
+from django.db.models import Exists, F, Max, OuterRef, Q, Subquery
 from django.utils import timezone
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import mixins, status, viewsets
@@ -38,7 +39,7 @@ from siarnaq.api.compete.serializers import (
 )
 from siarnaq.api.episodes.models import ReleaseStatus, Tournament
 from siarnaq.api.episodes.permissions import IsEpisodeAvailable, IsEpisodeMutable
-from siarnaq.api.teams.models import Team, TeamStatus
+from siarnaq.api.teams.models import Rating, Team, TeamStatus
 from siarnaq.api.teams.permissions import IsOnTeam
 from siarnaq.gcloud import titan
 
@@ -387,6 +388,61 @@ class MatchViewSet(
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
 
+    def get_historical_rating_ranking(self, episode_id, queryset, limit=None):
+
+        has_invisible = self.get_queryset().filter(
+            participants__team__status=TeamStatus.INVISIBLE
+        )
+        matches = (
+            (
+                queryset.filter(episode=episode_id)
+                .filter(tournament_round__isnull=True)
+                .exclude(pk__in=Subquery(has_invisible.values("pk")))
+                .filter(is_ranked=True)
+                .filter(participants__rating__isnull=False)
+            )
+            .all()
+            .order_by("-created")
+        )
+
+        # query aggregate rating history per each team order by
+        # max_rating and limit by 10
+        matching_participants = MatchParticipant.objects.all().filter(match__in=matches)
+        rating_history = (
+            matching_participants.values("team_id")
+            .annotate(
+                timestamps_list=ArrayAgg(
+                    F("match__created"), ordering="match__created"
+                ),
+                ratings_pk_list=ArrayAgg(F("rating__pk"), ordering="match__created"),
+                max_rating=Max("rating__value"),
+            )
+            .all()
+            .order_by("-max_rating")[:limit]
+        )
+        # parse query result in format required by serializer
+        # query returns team, rating as pk but we serializer
+        # needs pointer to team, rating objects
+        grouped = [
+            {
+                "team_id": team_data["team_id"],
+                "team_rating": {
+                    "team": Team.objects.get(pk=team_data["team_id"]),
+                    "rating_history": [
+                        {
+                            "timestamp": timestamp,
+                            "rating": Rating.objects.get(pk=rating_pk),
+                        }
+                        for rating_pk, timestamp in zip(
+                            team_data["ratings_pk_list"], team_data["timestamps_list"]
+                        )
+                    ],
+                },
+            }
+            for team_data in rating_history
+        ]
+        return grouped
+
     @extend_schema(
         parameters=[
             OpenApiParameter(
@@ -412,12 +468,9 @@ class MatchViewSet(
     )
     def historical_rating(self, request, pk=None, *, episode_id):
         """List the historical ratings of a list of teams."""
-        queryset = Match.objects.all().filter(tournament_round__isnull=True)
-
         team_ids = self.request.query_params.getlist("team_ids")
         if team_ids is not None and len(team_ids) > 0:
             team_ids = {parse_int(team_id) for team_id in team_ids}
-            queryset = queryset.filter(participants__team__in=team_ids)
         elif request.user.pk is not None:
             team_ids = {
                 team.id
@@ -425,37 +478,38 @@ class MatchViewSet(
                     episode_id=episode_id
                 )
             }
-            queryset = queryset.filter(participants__team__members=request.user.pk)
         else:
             return Response([])
-        has_invisible = self.get_queryset().filter(
-            participants__team__status=TeamStatus.INVISIBLE
+
+        queryset = Match.objects.all().filter(participants__team__in=team_ids)
+        grouped = self.get_historical_rating_ranking(episode_id, queryset)
+        results = HistoricalRatingSerializer(grouped, many=True).data
+        return Response(results, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        responses={
+            status.HTTP_204_NO_CONTENT: OpenApiResponse(
+                description="No ranked matches found."
+            ),
+            status.HTTP_200_OK: HistoricalRatingSerializer(many=True),
+        },
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        permission_classes=(IsEpisodeMutable,),
+        # needed so that the generated schema is not paginated
+        pagination_class=None,
+    )
+    def historical_rating_top10(self, request, pk=None, *, episode_id):
+        """List the historical top 10 rankings"""
+        # filter matches
+
+        queryset = Match.objects.all()
+        grouped = self.get_historical_rating_ranking(
+            episode_id=episode_id, queryset=queryset, limit=10
         )
-        queryset = queryset.exclude(pk__in=Subquery(has_invisible.values("pk")))
-        queryset = queryset.filter(is_ranked=True).filter(
-            participants__rating__isnull=False
-        )
-
-        matches = queryset.all().order_by("-created")
-        grouped = {
-            team_id: {"team_id": team_id, "team_rating": None} for team_id in team_ids
-        }
-
-        for match in matches:
-            matching_participants = match.participants.filter(team__in=team_ids).all()
-            for participant in matching_participants:
-                match_info = {"timestamp": match.created, "rating": participant.rating}
-                if grouped[participant.team.id]["team_rating"] is None:
-                    grouped[participant.team.id]["team_rating"] = {
-                        "team": participant.team,
-                        "rating_history": [match_info],
-                    }
-                else:
-                    grouped[participant.team.id]["team_rating"][
-                        "rating_history"
-                    ].append(match_info)
-
-        results = HistoricalRatingSerializer(grouped.values(), many=True).data
+        results = HistoricalRatingSerializer(grouped, many=True).data
         return Response(results, status=status.HTTP_200_OK)
 
     @extend_schema(

--- a/frontend2/schema.yml
+++ b/frontend2/schema.yml
@@ -156,7 +156,7 @@ paths:
         name: team_id
         schema:
           type: integer
-        description: An optional team ID to filter for. Defaults to your own team.
+        description: Optional teamID to filter for. Defaults to your own team.
       tags:
       - compete
       security:
@@ -172,11 +172,16 @@ paths:
                 items:
                   $ref: '#/components/schemas/HistoricalRating'
           description: ''
-  /api/compete/{episode_id}/match/historical_rating_top10/:
+  /api/compete/{episode_id}/match/historical_rating_topN/:
     get:
-      operationId: compete_match_historical_rating_top10_list
-      description: List the historical top 10 rankings
+      operationId: compete_match_historical_rating_topN_list
+      description: List the historical top N rankings
       parameters:
+      - in: query
+        name: N
+        schema:
+          type: integer
+        description: number of top teams to get ratings for, defaults to 10
       - in: path
         name: episode_id
         schema:

--- a/frontend2/schema.yml
+++ b/frontend2/schema.yml
@@ -144,7 +144,7 @@ paths:
   /api/compete/{episode_id}/match/historical_rating/:
     get:
       operationId: compete_match_historical_rating_list
-      description: List the historical ratings of a list of teams.
+      description: List the historical ratings of a team.
       parameters:
       - in: path
         name: episode_id
@@ -153,12 +153,10 @@ paths:
           pattern: ^[^\/.]+$
         required: true
       - in: query
-        name: team_ids
+        name: team_id
         schema:
-          type: array
-          items:
-            type: integer
-        description: A list of teams to filter for. Defaults to your own team.
+          type: integer
+        description: An optional team ID to filter for. Defaults to your own team.
       tags:
       - compete
       security:

--- a/frontend2/schema.yml
+++ b/frontend2/schema.yml
@@ -174,6 +174,32 @@ paths:
                 items:
                   $ref: '#/components/schemas/HistoricalRating'
           description: ''
+  /api/compete/{episode_id}/match/historical_rating_top10/:
+    get:
+      operationId: compete_match_historical_rating_top10_list
+      description: List the historical top 10 rankings
+      parameters:
+      - in: path
+        name: episode_id
+        schema:
+          type: string
+          pattern: ^[^\/.]+$
+        required: true
+      tags:
+      - compete
+      security:
+      - jwtAuth: []
+      responses:
+        '204':
+          description: No ranked matches found.
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HistoricalRating'
+          description: ''
   /api/compete/{episode_id}/match/scrimmage/:
     get:
       operationId: compete_match_scrimmage_list
@@ -1857,8 +1883,6 @@ components:
             type: integer
         min_score:
           type: integer
-          maximum: 32767
-          minimum: 0
       required:
       - episode
       - maps
@@ -3154,8 +3178,6 @@ components:
           type: string
         external_id:
           type: integer
-          maximum: 32767
-          minimum: -32768
           nullable: true
         name:
           type: string
@@ -3165,14 +3187,9 @@ components:
           items:
             type: integer
         release_status:
-          allOf:
-          - $ref: '#/components/schemas/ReleaseStatusEnum'
-          minimum: -2147483648
-          maximum: 2147483647
+          $ref: '#/components/schemas/ReleaseStatusEnum'
         display_order:
           type: integer
-          maximum: 32767
-          minimum: 0
       required:
       - display_order
       - id

--- a/frontend2/src/api/_autogen/apis/CompeteApi.ts
+++ b/frontend2/src/api/_autogen/apis/CompeteApi.ts
@@ -63,8 +63,9 @@ export interface CompeteMatchHistoricalRatingListRequest {
     teamId?: number;
 }
 
-export interface CompeteMatchHistoricalRatingTop10ListRequest {
+export interface CompeteMatchHistoricalRatingTopNListRequest {
     episodeId: string;
+    n?: number;
 }
 
 export interface CompeteMatchListRequest {
@@ -224,14 +225,18 @@ export class CompeteApi extends runtime.BaseAPI {
     }
 
     /**
-     * List the historical top 10 rankings
+     * List the historical top N rankings
      */
-    async competeMatchHistoricalRatingTop10ListRaw(requestParameters: CompeteMatchHistoricalRatingTop10ListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<HistoricalRating>>> {
+    async competeMatchHistoricalRatingTopNListRaw(requestParameters: CompeteMatchHistoricalRatingTopNListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<HistoricalRating>>> {
         if (requestParameters.episodeId === null || requestParameters.episodeId === undefined) {
-            throw new runtime.RequiredError('episodeId','Required parameter requestParameters.episodeId was null or undefined when calling competeMatchHistoricalRatingTop10List.');
+            throw new runtime.RequiredError('episodeId','Required parameter requestParameters.episodeId was null or undefined when calling competeMatchHistoricalRatingTopNList.');
         }
 
         const queryParameters: any = {};
+
+        if (requestParameters.n !== undefined) {
+            queryParameters['N'] = requestParameters.n;
+        }
 
         const headerParameters: runtime.HTTPHeaders = {};
 
@@ -244,7 +249,7 @@ export class CompeteApi extends runtime.BaseAPI {
             }
         }
         const response = await this.request({
-            path: `/api/compete/{episode_id}/match/historical_rating_top10/`.replace(`{${"episode_id"}}`, encodeURIComponent(String(requestParameters.episodeId))),
+            path: `/api/compete/{episode_id}/match/historical_rating_topN/`.replace(`{${"episode_id"}}`, encodeURIComponent(String(requestParameters.episodeId))),
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
@@ -254,10 +259,10 @@ export class CompeteApi extends runtime.BaseAPI {
     }
 
     /**
-     * List the historical top 10 rankings
+     * List the historical top N rankings
      */
-    async competeMatchHistoricalRatingTop10List(requestParameters: CompeteMatchHistoricalRatingTop10ListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<HistoricalRating>> {
-        const response = await this.competeMatchHistoricalRatingTop10ListRaw(requestParameters, initOverrides);
+    async competeMatchHistoricalRatingTopNList(requestParameters: CompeteMatchHistoricalRatingTopNListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<HistoricalRating>> {
+        const response = await this.competeMatchHistoricalRatingTopNListRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/frontend2/src/api/_autogen/apis/CompeteApi.ts
+++ b/frontend2/src/api/_autogen/apis/CompeteApi.ts
@@ -63,6 +63,10 @@ export interface CompeteMatchHistoricalRatingListRequest {
     teamIds?: Array<number>;
 }
 
+export interface CompeteMatchHistoricalRatingTop10ListRequest {
+    episodeId: string;
+}
+
 export interface CompeteMatchListRequest {
     episodeId: string;
     page?: number;
@@ -216,6 +220,44 @@ export class CompeteApi extends runtime.BaseAPI {
      */
     async competeMatchHistoricalRatingList(requestParameters: CompeteMatchHistoricalRatingListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<HistoricalRating>> {
         const response = await this.competeMatchHistoricalRatingListRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * List the historical top 10 rankings
+     */
+    async competeMatchHistoricalRatingTop10ListRaw(requestParameters: CompeteMatchHistoricalRatingTop10ListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<HistoricalRating>>> {
+        if (requestParameters.episodeId === null || requestParameters.episodeId === undefined) {
+            throw new runtime.RequiredError('episodeId','Required parameter requestParameters.episodeId was null or undefined when calling competeMatchHistoricalRatingTop10List.');
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            const token = this.configuration.accessToken;
+            const tokenString = await token("jwtAuth", []);
+
+            if (tokenString) {
+                headerParameters["Authorization"] = `Bearer ${tokenString}`;
+            }
+        }
+        const response = await this.request({
+            path: `/api/compete/{episode_id}/match/historical_rating_top10/`.replace(`{${"episode_id"}}`, encodeURIComponent(String(requestParameters.episodeId))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(HistoricalRatingFromJSON));
+    }
+
+    /**
+     * List the historical top 10 rankings
+     */
+    async competeMatchHistoricalRatingTop10List(requestParameters: CompeteMatchHistoricalRatingTop10ListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<HistoricalRating>> {
+        const response = await this.competeMatchHistoricalRatingTop10ListRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/frontend2/src/api/_autogen/apis/CompeteApi.ts
+++ b/frontend2/src/api/_autogen/apis/CompeteApi.ts
@@ -60,7 +60,7 @@ import {
 
 export interface CompeteMatchHistoricalRatingListRequest {
     episodeId: string;
-    teamIds?: Array<number>;
+    teamId?: number;
 }
 
 export interface CompeteMatchHistoricalRatingTop10ListRequest {
@@ -182,7 +182,7 @@ export interface CompeteSubmissionTournamentListRequest {
 export class CompeteApi extends runtime.BaseAPI {
 
     /**
-     * List the historical ratings of a list of teams.
+     * List the historical ratings of a team.
      */
     async competeMatchHistoricalRatingListRaw(requestParameters: CompeteMatchHistoricalRatingListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<HistoricalRating>>> {
         if (requestParameters.episodeId === null || requestParameters.episodeId === undefined) {
@@ -191,8 +191,8 @@ export class CompeteApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (requestParameters.teamIds) {
-            queryParameters['team_ids'] = requestParameters.teamIds;
+        if (requestParameters.teamId !== undefined) {
+            queryParameters['team_id'] = requestParameters.teamId;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -216,7 +216,7 @@ export class CompeteApi extends runtime.BaseAPI {
     }
 
     /**
-     * List the historical ratings of a list of teams.
+     * List the historical ratings of a team.
      */
     async competeMatchHistoricalRatingList(requestParameters: CompeteMatchHistoricalRatingListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<HistoricalRating>> {
         const response = await this.competeMatchHistoricalRatingListRaw(requestParameters, initOverrides);

--- a/frontend2/src/api/compete/competeApi.ts
+++ b/frontend2/src/api/compete/competeApi.ts
@@ -19,6 +19,7 @@ import {
   type CompeteMatchListRequest,
   type CompeteSubmissionTournamentListRequest,
   type CompeteRequestDestroyRequest,
+  type CompeteMatchHistoricalRatingTop10ListRequest,
   type CompeteMatchHistoricalRatingListRequest,
   type HistoricalRating,
   type CompeteMatchScrimmagingRecordRetrieveRequest,
@@ -213,6 +214,16 @@ export const getMatchesList = async ({
   page,
 }: CompeteMatchListRequest): Promise<PaginatedMatchList> =>
   await API.competeMatchList({ episodeId, page });
+
+/**
+ * Get the rating history for top 10 teams in a given episode.
+ *
+ * @param episodeId The episode ID to retrieve rating data for.
+ */
+export const getRatingTop10List = async ({
+  episodeId,
+}: CompeteMatchHistoricalRatingTop10ListRequest): Promise<HistoricalRating[]> =>
+  await API.competeMatchHistoricalRatingTop10List({ episodeId });
 
 /**
  * Get the rating history for a list of teams in a given episode.

--- a/frontend2/src/api/compete/competeApi.ts
+++ b/frontend2/src/api/compete/competeApi.ts
@@ -226,17 +226,17 @@ export const getRatingTop10List = async ({
   await API.competeMatchHistoricalRatingTop10List({ episodeId });
 
 /**
- * Get the rating history for a list of teams in a given episode.
- * Defaults to the logged in user's team if no team IDs are provided.
+ * Get the rating history for a teamsin a given episode.
+ * Defaults to the logged in user's team if no team ID are provided.
  *
  * @param episodeId The episode ID to retrieve rating data for.
- * @param teamIds The team IDs to retrieve rating data for.
+ * @param teamId The team ID to retrieve rating data for.
  */
 export const getRatingList = async ({
   episodeId,
-  teamIds,
+  teamId,
 }: CompeteMatchHistoricalRatingListRequest): Promise<HistoricalRating[]> =>
-  await API.competeMatchHistoricalRatingList({ episodeId, teamIds });
+  await API.competeMatchHistoricalRatingList({ episodeId, teamId });
 
 /**
  * Get a team's win-loss-tie record in scrimmages in a given episode. Defaults to the logged in user's team.

--- a/frontend2/src/api/compete/competeApi.ts
+++ b/frontend2/src/api/compete/competeApi.ts
@@ -19,7 +19,7 @@ import {
   type CompeteMatchListRequest,
   type CompeteSubmissionTournamentListRequest,
   type CompeteRequestDestroyRequest,
-  type CompeteMatchHistoricalRatingTop10ListRequest,
+  type CompeteMatchHistoricalRatingTopNListRequest,
   type CompeteMatchHistoricalRatingListRequest,
   type HistoricalRating,
   type CompeteMatchScrimmagingRecordRetrieveRequest,
@@ -220,10 +220,11 @@ export const getMatchesList = async ({
  *
  * @param episodeId The episode ID to retrieve rating data for.
  */
-export const getRatingTop10List = async ({
+export const getRatingTopNList = async ({
   episodeId,
-}: CompeteMatchHistoricalRatingTop10ListRequest): Promise<HistoricalRating[]> =>
-  await API.competeMatchHistoricalRatingTop10List({ episodeId });
+  n,
+}: CompeteMatchHistoricalRatingTopNListRequest): Promise<HistoricalRating[]> =>
+  await API.competeMatchHistoricalRatingTopNList({ episodeId, n });
 
 /**
  * Get the rating history for a teamsin a given episode.

--- a/frontend2/src/api/compete/competeFactories.ts
+++ b/frontend2/src/api/compete/competeFactories.ts
@@ -1,4 +1,5 @@
 import type {
+  CompeteMatchHistoricalRatingTop10ListRequest,
   CompeteMatchHistoricalRatingListRequest,
   CompeteMatchListRequest,
   CompeteMatchScrimmageListRequest,
@@ -20,6 +21,7 @@ import { competeQueryKeys } from "./competeKeys";
 import {
   getAllUserTournamentSubmissions,
   getMatchesList,
+  getRatingTop10List,
   getRatingList,
   getScrimmagesListByTeam,
   getScrimmagingRecord,
@@ -192,6 +194,14 @@ export const tournamentMatchListFactory: PaginatedQueryFactory<
 
     return result;
   },
+} as const;
+
+export const ratingHistoryTop10Factory: QueryFactory<
+  CompeteMatchHistoricalRatingTop10ListRequest,
+  HistoricalRating[]
+> = {
+  queryKey: competeQueryKeys.ratingHistoryTopList,
+  queryFn: async ({ episodeId }) => await getRatingTop10List({ episodeId }),
 } as const;
 
 export const ratingHistoryTopFactory: QueryFactory<

--- a/frontend2/src/api/compete/competeFactories.ts
+++ b/frontend2/src/api/compete/competeFactories.ts
@@ -1,5 +1,5 @@
 import type {
-  CompeteMatchHistoricalRatingTop10ListRequest,
+  CompeteMatchHistoricalRatingTopNListRequest,
   CompeteMatchHistoricalRatingListRequest,
   CompeteMatchListRequest,
   CompeteMatchScrimmageListRequest,
@@ -21,7 +21,7 @@ import { competeQueryKeys } from "./competeKeys";
 import {
   getAllUserTournamentSubmissions,
   getMatchesList,
-  getRatingTop10List,
+  getRatingTopNList,
   getRatingList,
   getScrimmagesListByTeam,
   getScrimmagingRecord,
@@ -196,12 +196,13 @@ export const tournamentMatchListFactory: PaginatedQueryFactory<
   },
 } as const;
 
-export const ratingHistoryTop10Factory: QueryFactory<
-  CompeteMatchHistoricalRatingTop10ListRequest,
+export const ratingHistoryTopNFactory: QueryFactory<
+  CompeteMatchHistoricalRatingTopNListRequest,
   HistoricalRating[]
 > = {
-  queryKey: competeQueryKeys.ratingHistoryTop10List,
-  queryFn: async ({ episodeId }) => await getRatingTop10List({ episodeId }),
+  queryKey: competeQueryKeys.ratingHistoryTopNList,
+  queryFn: async ({ episodeId, n }) =>
+    await getRatingTopNList({ episodeId, n }),
 } as const;
 
 export const ratingHistoryFactory: QueryFactory<

--- a/frontend2/src/api/compete/competeFactories.ts
+++ b/frontend2/src/api/compete/competeFactories.ts
@@ -200,17 +200,17 @@ export const ratingHistoryTop10Factory: QueryFactory<
   CompeteMatchHistoricalRatingTop10ListRequest,
   HistoricalRating[]
 > = {
-  queryKey: competeQueryKeys.ratingHistoryTopList,
+  queryKey: competeQueryKeys.ratingHistoryTop10List,
   queryFn: async ({ episodeId }) => await getRatingTop10List({ episodeId }),
 } as const;
 
-export const ratingHistoryTopFactory: QueryFactory<
+export const ratingHistoryFactory: QueryFactory<
   CompeteMatchHistoricalRatingListRequest,
   HistoricalRating[]
 > = {
   queryKey: competeQueryKeys.ratingHistoryTopList,
-  queryFn: async ({ episodeId, teamIds }) =>
-    await getRatingList({ episodeId, teamIds }),
+  queryFn: async ({ episodeId, teamId }) =>
+    await getRatingList({ episodeId, teamId }),
 } as const;
 
 export const ratingHistoryMeFactory: QueryFactory<
@@ -219,7 +219,7 @@ export const ratingHistoryMeFactory: QueryFactory<
 > = {
   queryKey: competeQueryKeys.ratingHistoryMeList,
   queryFn: async ({ episodeId }) =>
-    await getRatingList({ episodeId, teamIds: undefined }),
+    await getRatingList({ episodeId, teamId: undefined }),
 } as const;
 
 export const scrimmagingRecordFactory: QueryFactory<

--- a/frontend2/src/api/compete/competeKeys.ts
+++ b/frontend2/src/api/compete/competeKeys.ts
@@ -1,5 +1,5 @@
 import type {
-  CompeteMatchHistoricalRatingTop10ListRequest,
+  CompeteMatchHistoricalRatingTopNListRequest,
   CompeteMatchHistoricalRatingListRequest,
   CompeteMatchListRequest,
   CompeteMatchScrimmageListRequest,
@@ -29,7 +29,7 @@ interface CompeteKeys {
   tourneyMatchList: QueryKeyBuilder<CompeteMatchTournamentListRequest>;
   // --- PERFORMANCE --- //
   ratingHistoryBase: QueryKeyBuilder<{ episodeId: string }>;
-  ratingHistoryTop10List: QueryKeyBuilder<CompeteMatchHistoricalRatingTop10ListRequest>;
+  ratingHistoryTopNList: QueryKeyBuilder<CompeteMatchHistoricalRatingTopNListRequest>;
   ratingHistoryTopList: QueryKeyBuilder<CompeteMatchHistoricalRatingListRequest>;
   ratingHistoryMeList: QueryKeyBuilder<CompeteMatchHistoricalRatingListRequest>;
   scrimmagingRecord: QueryKeyBuilder<CompeteMatchScrimmagingRecordRetrieveRequest>;
@@ -132,11 +132,12 @@ export const competeQueryKeys: CompeteKeys = {
       ["compete", episodeId, "ratingHistory"] as const,
   },
 
-  ratingHistoryTop10List: {
-    key: ({ episodeId }: CompeteMatchHistoricalRatingTop10ListRequest) =>
+  ratingHistoryTopNList: {
+    key: ({ episodeId, n }: CompeteMatchHistoricalRatingTopNListRequest) =>
       [
         ...competeQueryKeys.ratingHistoryBase.key({ episodeId }),
         "top",
+        n,
       ] as const,
   },
 

--- a/frontend2/src/api/compete/competeKeys.ts
+++ b/frontend2/src/api/compete/competeKeys.ts
@@ -1,4 +1,5 @@
 import type {
+  CompeteMatchHistoricalRatingTop10ListRequest,
   CompeteMatchHistoricalRatingListRequest,
   CompeteMatchListRequest,
   CompeteMatchScrimmageListRequest,
@@ -28,6 +29,7 @@ interface CompeteKeys {
   tourneyMatchList: QueryKeyBuilder<CompeteMatchTournamentListRequest>;
   // --- PERFORMANCE --- //
   ratingHistoryBase: QueryKeyBuilder<{ episodeId: string }>;
+  ratingHistoryTop10List: QueryKeyBuilder<CompeteMatchHistoricalRatingTop10ListRequest>;
   ratingHistoryTopList: QueryKeyBuilder<CompeteMatchHistoricalRatingListRequest>;
   ratingHistoryMeList: QueryKeyBuilder<CompeteMatchHistoricalRatingListRequest>;
   scrimmagingRecord: QueryKeyBuilder<CompeteMatchScrimmagingRecordRetrieveRequest>;
@@ -128,6 +130,14 @@ export const competeQueryKeys: CompeteKeys = {
   ratingHistoryBase: {
     key: ({ episodeId }: { episodeId: string }) =>
       ["compete", episodeId, "ratingHistory"] as const,
+  },
+
+  ratingHistoryTop10List: {
+    key: ({ episodeId }: CompeteMatchHistoricalRatingTop10ListRequest) =>
+      [
+        ...competeQueryKeys.ratingHistoryBase.key({ episodeId }),
+        "top",
+      ] as const,
   },
 
   ratingHistoryTopList: {

--- a/frontend2/src/api/compete/useCompete.ts
+++ b/frontend2/src/api/compete/useCompete.ts
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-query";
 import { competeMutationKeys, competeQueryKeys } from "./competeKeys";
 import type {
-  CompeteMatchHistoricalRatingTop10ListRequest,
+  CompeteMatchHistoricalRatingTopNListRequest,
   CompeteMatchHistoricalRatingListRequest,
   CompeteMatchListRequest,
   CompeteMatchScrimmageListRequest,
@@ -47,7 +47,7 @@ import toast from "react-hot-toast";
 import { buildKey } from "../helpers";
 import {
   matchListFactory,
-  ratingHistoryTop10Factory,
+  ratingHistoryTopNFactory,
   ratingHistoryMeFactory,
   scrimmageInboxListFactory,
   scrimmageOutboxListFactory,
@@ -209,15 +209,17 @@ export const useTournamentMatchList = (
  */
 export const useTopRatingHistoryList = ({
   episodeId,
-}: CompeteMatchHistoricalRatingTop10ListRequest): UseQueryResult<
+  n,
+}: CompeteMatchHistoricalRatingTopNListRequest): UseQueryResult<
   HistoricalRating[],
   Error
 > =>
   useQuery({
-    queryKey: buildKey(ratingHistoryTop10Factory.queryKey, { episodeId }),
+    queryKey: buildKey(ratingHistoryTopNFactory.queryKey, { episodeId, n }),
     queryFn: async () => {
-      return await ratingHistoryTop10Factory.queryFn({
+      return await ratingHistoryTopNFactory.queryFn({
         episodeId,
+        n,
       });
     },
     staleTime: 1000 * 60 * 5, // 5 minutes

--- a/frontend2/src/api/compete/useCompete.ts
+++ b/frontend2/src/api/compete/useCompete.ts
@@ -9,6 +9,7 @@ import {
 } from "@tanstack/react-query";
 import { competeMutationKeys, competeQueryKeys } from "./competeKeys";
 import type {
+  CompeteMatchHistoricalRatingTop10ListRequest,
   CompeteMatchHistoricalRatingListRequest,
   CompeteMatchListRequest,
   CompeteMatchScrimmageListRequest,
@@ -28,7 +29,6 @@ import type {
   PaginatedMatchList,
   PaginatedScrimmageRequestList,
   PaginatedSubmissionList,
-  PaginatedTeamPublicList,
   ResponseError,
   ScrimmageRecord,
   ScrimmageRequest,
@@ -47,8 +47,8 @@ import toast from "react-hot-toast";
 import { buildKey } from "../helpers";
 import {
   matchListFactory,
+  ratingHistoryTop10Factory,
   ratingHistoryMeFactory,
-  ratingHistoryTopFactory,
   scrimmageInboxListFactory,
   scrimmageOutboxListFactory,
   scrimmagingRecordFactory,
@@ -58,8 +58,6 @@ import {
   tournamentSubsListFactory,
   userScrimmageListFactory,
 } from "./competeFactories";
-import { searchTeamsFactory } from "api/team/teamFactories";
-import { isPresent } from "utils/utilTypes";
 
 // ---------- QUERY HOOKS ---------- //
 /**
@@ -209,34 +207,18 @@ export const useTournamentMatchList = (
 /**
  * For retrieving a list of the top 10 teams' historical ratings in a given episode.
  */
-export const useTopRatingHistoryList = (
-  { episodeId }: CompeteMatchHistoricalRatingListRequest,
-  queryClient: QueryClient,
-): UseQueryResult<HistoricalRating[], Error> =>
+export const useTopRatingHistoryList = ({
+  episodeId,
+}: CompeteMatchHistoricalRatingTop10ListRequest): UseQueryResult<
+  HistoricalRating[],
+  Error
+> =>
   useQuery({
-    queryKey: buildKey(ratingHistoryTopFactory.queryKey, { episodeId }),
+    queryKey: buildKey(ratingHistoryTop10Factory.queryKey, { episodeId }),
     queryFn: async () => {
-      // Get the query data for the top 10 teams in this episode
-      const topTeamsData: PaginatedTeamPublicList | undefined =
-        await queryClient.ensureQueryData({
-          queryKey: buildKey(searchTeamsFactory.queryKey, { episodeId }),
-          queryFn: async () =>
-            await searchTeamsFactory.queryFn(
-              { episodeId, page: 1 },
-              queryClient,
-              false, // We don't want to prefetch teams 11-20
-            ),
-        });
-      // Fetch their rating histories
-      if (isPresent(topTeamsData) && isPresent(topTeamsData.results)) {
-        const topTeamsIds = topTeamsData.results.map((team) => team.id);
-        return await ratingHistoryTopFactory.queryFn({
-          episodeId,
-          teamIds: topTeamsIds,
-        });
-      } else {
-        return [];
-      }
+      return await ratingHistoryTop10Factory.queryFn({
+        episodeId,
+      });
     },
     staleTime: 1000 * 60 * 5, // 5 minutes
   });

--- a/frontend2/src/api/loaders/episodeLoader.ts
+++ b/frontend2/src/api/loaders/episodeLoader.ts
@@ -2,6 +2,7 @@ import { type QueryClient } from "@tanstack/react-query";
 import { ResponseError } from "api/_autogen";
 import { loginCheck } from "api/auth/authApi";
 import { episodeInfoFactory } from "api/episode/episodeFactories";
+import { ratingHistoryTop10Factory } from "api/compete/competeFactories";
 import { buildKey, safeEnsureQueryData } from "api/helpers";
 import { searchTeamsFactory, myTeamFactory } from "api/team/teamFactories";
 import { type LoaderFunction } from "react-router-dom";
@@ -35,6 +36,11 @@ export const episodeLoader =
         page: 1,
       },
       searchTeamsFactory,
+      queryClient,
+    );
+    safeEnsureQueryData(
+      { episodeId: id },
+      ratingHistoryTop10Factory,
       queryClient,
     );
 

--- a/frontend2/src/api/loaders/episodeLoader.ts
+++ b/frontend2/src/api/loaders/episodeLoader.ts
@@ -2,7 +2,7 @@ import { type QueryClient } from "@tanstack/react-query";
 import { ResponseError } from "api/_autogen";
 import { loginCheck } from "api/auth/authApi";
 import { episodeInfoFactory } from "api/episode/episodeFactories";
-import { ratingHistoryTop10Factory } from "api/compete/competeFactories";
+import { ratingHistoryTopNFactory } from "api/compete/competeFactories";
 import { buildKey, safeEnsureQueryData } from "api/helpers";
 import { searchTeamsFactory, myTeamFactory } from "api/team/teamFactories";
 import { type LoaderFunction } from "react-router-dom";
@@ -39,8 +39,8 @@ export const episodeLoader =
       queryClient,
     );
     safeEnsureQueryData(
-      { episodeId: id },
-      ratingHistoryTop10Factory,
+      { episodeId: id, n: 10 },
+      ratingHistoryTopNFactory,
       queryClient,
     );
 

--- a/frontend2/src/views/Home.tsx
+++ b/frontend2/src/views/Home.tsx
@@ -8,7 +8,6 @@ import { SocialIcon } from "react-social-icons";
 import TeamChart, {
   type ChartData,
 } from "../components/tables/chart/TeamChart";
-import { useQueryClient } from "@tanstack/react-query";
 import {
   useTopRatingHistoryList,
   useUserRatingHistoryList,
@@ -18,10 +17,9 @@ import { useUserTeam } from "api/team/useTeam";
 
 const Home: React.FC = () => {
   const { episodeId } = useEpisodeId();
-  const queryClient = useQueryClient();
   const episode = useEpisodeInfo({ id: episodeId });
   const nextTournament = useNextTournament({ episodeId });
-  const topRatingHistory = useTopRatingHistoryList({ episodeId }, queryClient);
+  const topRatingHistory = useTopRatingHistoryList({ episodeId });
   const userTeam = useUserTeam({ episodeId });
   const userTeamRatingHistory = useUserRatingHistoryList({ episodeId });
 

--- a/frontend2/src/views/Home.tsx
+++ b/frontend2/src/views/Home.tsx
@@ -19,7 +19,7 @@ const Home: React.FC = () => {
   const { episodeId } = useEpisodeId();
   const episode = useEpisodeInfo({ id: episodeId });
   const nextTournament = useNextTournament({ episodeId });
-  const topRatingHistory = useTopRatingHistoryList({ episodeId });
+  const topRatingHistory = useTopRatingHistoryList({ episodeId, n: 10 });
   const userTeam = useUserTeam({ episodeId });
   const userTeamRatingHistory = useUserRatingHistoryList({ episodeId });
 


### PR DESCRIPTION
created a new endpoint that returns the rating history for the top 10
rewrite the frontend useTopRating HistoryList to use this endpoint 
rewrite the backend historical_rating