### PR TITLE
Remove duplicated team biography on team profile view

### DIFF
--- a/frontend/src/views/TeamProfile.tsx
+++ b/frontend/src/views/TeamProfile.tsx
@@ -96,16 +96,6 @@ const TeamProfile: React.FC = () => {
                     )}
                   </div>
                   <div>
-                    <div className="font-medium">Biography</div>
-                    <div className="text-sm text-gray-800">
-                      {isNilOrEmptyStr(team.data.profile?.biography) ? (
-                        <span className="italic text-gray-500">
-                          This team does not have a biography
-                        </span>
-                      ) : (
-                        team.data.profile?.biography
-                      )}
-                    </div>
                     <div>
                       <div className="font-medium">Team biography</div>
                       <div className="text-sm text-gray-800">

--- a/frontend/src/views/TeamProfile.tsx
+++ b/frontend/src/views/TeamProfile.tsx
@@ -97,7 +97,7 @@ const TeamProfile: React.FC = () => {
                   </div>
                   <div>
                     <div>
-                      <div className="font-medium">Team biography</div>
+                      <div className="font-medium">Biography</div>
                       <div className="text-sm text-gray-800">
                         {isNilOrEmptyStr(team.data.profile?.biography) ? (
                           <span className="italic text-gray-500">


### PR DESCRIPTION
Removes "Team Biography" section below "Biography" on team profile page. ("Biography" more consistent with rest of profile than "Team Biography")