### PR TITLE
Tournament admin page

### DIFF
--- a/backend/siarnaq/api/compete/test_views.py
+++ b/backend/siarnaq/api/compete/test_views.py
@@ -406,6 +406,7 @@ class MatchSerializerTestCase(TestCase):
                     "maps": None,
                     "release_status": self.r_hidden.release_status,
                     "display_order": self.r_hidden.display_order,
+                    "in_progress": self.r_hidden.in_progress,
                 },
                 "participants": [
                     {
@@ -556,6 +557,7 @@ class MatchSerializerTestCase(TestCase):
                     "maps": [self.map.pk],
                     "release_status": self.r_results.release_status,
                     "display_order": self.r_results.display_order,
+                    "in_progress": self.r_results.in_progress,
                 },
                 "participants": [
                     {
@@ -635,6 +637,7 @@ class MatchSerializerTestCase(TestCase):
                     "maps": None,
                     "release_status": self.r_participants.release_status,
                     "display_order": self.r_participants.display_order,
+                    "in_progress": self.r_participants.in_progress,
                 },
                 "participants": [
                     {
@@ -714,6 +717,7 @@ class MatchSerializerTestCase(TestCase):
                     "maps": None,
                     "release_status": self.r_hidden.release_status,
                     "display_order": self.r_hidden.display_order,
+                    "in_progress": self.r_hidden.in_progress,
                 },
                 "participants": None,
                 "maps": None,

--- a/backend/siarnaq/api/episodes/serializers.py
+++ b/backend/siarnaq/api/episodes/serializers.py
@@ -101,6 +101,7 @@ class TournamentRoundSerializer(serializers.ModelSerializer):
             "maps",
             "release_status",
             "display_order",
+            "in_progress",
         ]
 
     def to_representation(self, instance):

--- a/backend/siarnaq/api/episodes/serializers.py
+++ b/backend/siarnaq/api/episodes/serializers.py
@@ -109,3 +109,7 @@ class TournamentRoundSerializer(serializers.ModelSerializer):
         if instance.release_status != ReleaseStatus.RESULTS:
             data["maps"] = None
         return data
+
+
+class EmptySerializer(serializers.Serializer):
+    pass

--- a/backend/siarnaq/api/episodes/views.py
+++ b/backend/siarnaq/api/episodes/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAdminUser
@@ -10,6 +10,7 @@ from siarnaq.api.episodes.models import Episode, Map, Tournament, TournamentRoun
 from siarnaq.api.episodes.permissions import IsEpisodeAvailable
 from siarnaq.api.episodes.serializers import (
     AutoscrimSerializer,
+    EmptySerializer,
     EpisodeSerializer,
     MapSerializer,
     TournamentRoundSerializer,
@@ -97,6 +98,31 @@ class TournamentViewSet(viewsets.ReadOnlyModelViewSet):
         serializer = self.get_serializer(next_tournament)
         return Response(serializer.data)
 
+    @extend_schema(
+        responses={
+            status.HTTP_204_NO_CONTENT: OpenApiResponse(
+                description="Tournament has been initialized"
+            ),
+        }
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        permission_classes=(IsAdminUser,),
+        serializer_class=EmptySerializer,
+        throttle_classes=(),
+    )
+    def initialize(self, request, pk=None, *, episode_id):
+        """
+        Seed the tournament with eligible teams in order of decreasing rating,
+        populate the brackets in the bracket service, and create TournamentRounds.
+        """
+        instance = self.get_object()
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        instance.initialize()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
 
 class TournamentRoundViewSet(viewsets.ReadOnlyModelViewSet):
     """
@@ -118,3 +144,100 @@ class TournamentRoundViewSet(viewsets.ReadOnlyModelViewSet):
         if not self.request.user.is_staff:
             queryset = queryset.filter(tournament__is_public=True)
         return queryset
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="episode_id",
+                type=str,
+                description="An episode to filter for.",
+            ),
+            OpenApiParameter(
+                name="tournament",
+                type=str,
+                description="A tournament to filter for.",
+            ),
+            OpenApiParameter(
+                name="id",
+                type=str,
+                description="A tournament round to filter for.",
+            ),
+            OpenApiParameter(
+                name="maps",
+                type=int,
+                many=True,
+                required=True,
+                description="List of map IDs to use in this round.",
+            ),
+        ],
+        responses={
+            status.HTTP_204_NO_CONTENT: OpenApiResponse(
+                description="Tournament round has been enqueued"
+            ),
+            status.HTTP_400_BAD_REQUEST: OpenApiResponse(
+                description="Tournament round could not be enqueued"
+            ),
+            status.HTTP_409_CONFLICT: OpenApiResponse(
+                description="Tournament round is already in progress"
+            ),
+        },
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        permission_classes=(IsAdminUser,),
+        serializer_class=EmptySerializer,
+    )
+    def enqueue(self, request, pk=None, *, episode_id, tournament):
+        """
+        Enqueue the given round of the tournament.
+        Fails if this round is already in progress.
+        """
+        instance = self.get_object()
+
+        # Set the tournament round's maps to the provided list
+        old_maps = instance.maps.all()
+        map_ids = self.request.query_params.getlist("maps")
+        maps = Map.objects.filter(episode_id=episode_id, id__in=map_ids)
+
+        # We require an odd number of maps to prevent ties
+        if len(maps) % 2 == 0:
+            return Response(None, status=status.HTTP_400_BAD_REQUEST)
+
+        instance.maps.set(maps)
+
+        # Attempt to enqueue the round
+        try:
+            instance.enqueue()
+        except RuntimeError as e:
+            # Revert the maps if enqueueing failed
+            instance.maps.set(old_maps)
+            return Response(str(e), status=status.HTTP_409_CONFLICT)
+
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        responses={
+            status.HTTP_204_NO_CONTENT: OpenApiResponse(
+                description=(
+                    "Tournament round has been released to public bracket service"
+                )
+            ),
+        }
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        permission_classes=(IsAdminUser,),
+        serializer_class=EmptySerializer,
+        throttle_classes=(),
+    )
+    def release(self, request, pk=None, *, episode_id):
+        """
+        Release the results of this round to the public bracket service.
+        """
+        instance = self.get_object()
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        instance.request_publish_to_bracket(is_public=True)
+        return Response(None, status=status.HTTP_204_NO_CONTENT)

--- a/frontend/schema.yml
+++ b/frontend/schema.yml
@@ -972,6 +972,50 @@ paths:
             type: string
             pattern: ^[^\/.]+$
           required: true
+        - in: query
+          name: episode_id
+          schema:
+            type: string
+          description: An episode to filter for.
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+        - in: query
+          name: id
+          schema:
+            type: string
+          description: A tournament round to filter for.
+        - in: path
+          name: tournament
+          schema:
+            type: string
+            pattern: ^[^\/.]+$
+          required: true
+        - in: query
+          name: tournament
+          schema:
+            type: string
+          description: A tournament to filter for.
+      tags:
+        - episode
+      security:
+        - jwtAuth: []
+      responses:
+        "204":
+          description: Tournament round has been released to public bracket service
+  /api/episode/{episode_id}/tournament/{tournament}/round/{id}/requeue/:
+    post:
+      operationId: episode_tournament_round_requeue_create
+      description: Re-queue every unsuccessful match in this round on Saturn.
+      parameters:
+        - in: path
+          name: episode_id
+          schema:
+            type: string
+            pattern: ^[^\/.]+$
+          required: true
         - in: path
           name: id
           schema:
@@ -989,7 +1033,9 @@ paths:
         - jwtAuth: []
       responses:
         "204":
-          description: Tournament round has been released to public bracket service
+          description: Tournament round has been requeued
+        "400":
+          description: No failed matches to requeue
   /api/episode/{episode_id}/tournament/next/:
     get:
       operationId: episode_tournament_next_retrieve
@@ -3485,6 +3531,8 @@ components:
           type: integer
           maximum: 32767
           minimum: 0
+        in_progress:
+          type: boolean
       required:
         - display_order
         - id

--- a/frontend/schema.yml
+++ b/frontend/schema.yml
@@ -811,6 +811,31 @@ paths:
               schema:
                 $ref: "#/components/schemas/Tournament"
           description: ""
+  /api/episode/{episode_id}/tournament/{id}/initialize/:
+    post:
+      operationId: episode_tournament_initialize_create
+      description: |-
+        Seed the tournament with eligible teams in order of decreasing rating,
+        populate the brackets in the bracket service, and create TournamentRounds.
+      parameters:
+        - in: path
+          name: episode_id
+          schema:
+            type: string
+            pattern: ^[^\/.]+$
+          required: true
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+      tags:
+        - episode
+      security:
+        - jwtAuth: []
+      responses:
+        "204":
+          description: Tournament has been initialized
   /api/episode/{episode_id}/tournament/{tournament}/round/:
     get:
       operationId: episode_tournament_round_list
@@ -878,6 +903,93 @@ paths:
               schema:
                 $ref: "#/components/schemas/TournamentRound"
           description: ""
+  /api/episode/{episode_id}/tournament/{tournament}/round/{id}/enqueue/:
+    post:
+      operationId: episode_tournament_round_enqueue_create
+      description: |-
+        Enqueue the given round of the tournament.
+        Fails if this round is already in progress.
+      parameters:
+        - in: path
+          name: episode_id
+          schema:
+            type: string
+            pattern: ^[^\/.]+$
+          required: true
+        - in: query
+          name: episode_id
+          schema:
+            type: string
+          description: An episode to filter for.
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+        - in: query
+          name: id
+          schema:
+            type: string
+          description: A tournament round to filter for.
+        - in: query
+          name: maps
+          schema:
+            type: array
+            items:
+              type: integer
+          description: List of map IDs to use in this round.
+          required: true
+        - in: path
+          name: tournament
+          schema:
+            type: string
+            pattern: ^[^\/.]+$
+          required: true
+        - in: query
+          name: tournament
+          schema:
+            type: string
+          description: A tournament to filter for.
+      tags:
+        - episode
+      security:
+        - jwtAuth: []
+      responses:
+        "204":
+          description: Tournament round has been enqueued
+        "400":
+          description: Tournament round could not be enqueued
+        "409":
+          description: Tournament round is already in progress
+  /api/episode/{episode_id}/tournament/{tournament}/round/{id}/release/:
+    post:
+      operationId: episode_tournament_round_release_create
+      description: Release the results of this round to the public bracket service.
+      parameters:
+        - in: path
+          name: episode_id
+          schema:
+            type: string
+            pattern: ^[^\/.]+$
+          required: true
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: tournament
+          schema:
+            type: string
+            pattern: ^[^\/.]+$
+          required: true
+      tags:
+        - episode
+      security:
+        - jwtAuth: []
+      responses:
+        "204":
+          description: Tournament round has been released to public bracket service
   /api/episode/{episode_id}/tournament/next/:
     get:
       operationId: episode_tournament_next_retrieve

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,6 +57,7 @@ import { HttpStatusCode } from "api/apiTypes";
 import { accountLoader } from "api/loaders/accountLoader";
 import CodeOfConduct from "views/CodeOfConduct";
 import Client from "views/Client";
+import AdminTournament from "views/AdminTournament";
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
@@ -221,6 +222,11 @@ const router = createBrowserRouter([
         path: "tournament/:tournamentId",
         element: <TournamentPage />,
         loader: tournamentLoader(queryClient),
+        errorElement: <ErrorBoundary />,
+      },
+      {
+        path: "tournament/:tournamentId/admin",
+        element: <AdminTournament />,
         errorElement: <ErrorBoundary />,
       },
       {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,6 +58,7 @@ import { accountLoader } from "api/loaders/accountLoader";
 import CodeOfConduct from "views/CodeOfConduct";
 import Client from "views/Client";
 import AdminTournament from "views/AdminTournament";
+import { adminTournamentLoader } from "api/loaders/adminTournamentLoader";
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
@@ -228,6 +229,7 @@ const router = createBrowserRouter([
         path: "tournament/:tournamentId/admin",
         element: <AdminTournament />,
         errorElement: <ErrorBoundary />,
+        loader: adminTournamentLoader(queryClient),
       },
       {
         path: "team/:teamId",

--- a/frontend/src/api/_autogen/apis/EpisodeApi.ts
+++ b/frontend/src/api/_autogen/apis/EpisodeApi.ts
@@ -65,6 +65,11 @@ export interface EpisodeMapRetrieveRequest {
     id: string;
 }
 
+export interface EpisodeTournamentInitializeCreateRequest {
+    episodeId: string;
+    id: string;
+}
+
 export interface EpisodeTournamentListRequest {
     episodeId: string;
     page?: number;
@@ -79,10 +84,26 @@ export interface EpisodeTournamentRetrieveRequest {
     id: string;
 }
 
+export interface EpisodeTournamentRoundEnqueueCreateRequest {
+    episodeId: string;
+    id: string;
+    maps: Array<number>;
+    tournament: string;
+    episodeId2?: string;
+    id2?: string;
+    tournament2?: string;
+}
+
 export interface EpisodeTournamentRoundListRequest {
     episodeId: string;
     tournament: string;
     page?: number;
+}
+
+export interface EpisodeTournamentRoundReleaseCreateRequest {
+    episodeId: string;
+    id: string;
+    tournament: string;
 }
 
 export interface EpisodeTournamentRoundRetrieveRequest {
@@ -297,6 +318,47 @@ export class EpisodeApi extends runtime.BaseAPI {
     }
 
     /**
+     * Seed the tournament with eligible teams in order of decreasing rating, populate the brackets in the bracket service, and create TournamentRounds.
+     */
+    async episodeTournamentInitializeCreateRaw(requestParameters: EpisodeTournamentInitializeCreateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
+        if (requestParameters.episodeId === null || requestParameters.episodeId === undefined) {
+            throw new runtime.RequiredError('episodeId','Required parameter requestParameters.episodeId was null or undefined when calling episodeTournamentInitializeCreate.');
+        }
+
+        if (requestParameters.id === null || requestParameters.id === undefined) {
+            throw new runtime.RequiredError('id','Required parameter requestParameters.id was null or undefined when calling episodeTournamentInitializeCreate.');
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            const token = this.configuration.accessToken;
+            const tokenString = await token("jwtAuth", []);
+
+            if (tokenString) {
+                headerParameters["Authorization"] = `Bearer ${tokenString}`;
+            }
+        }
+        const response = await this.request({
+            path: `/api/episode/{episode_id}/tournament/{id}/initialize/`.replace(`{${"episode_id"}}`, encodeURIComponent(String(requestParameters.episodeId))).replace(`{${"id"}}`, encodeURIComponent(String(requestParameters.id))),
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     * Seed the tournament with eligible teams in order of decreasing rating, populate the brackets in the bracket service, and create TournamentRounds.
+     */
+    async episodeTournamentInitializeCreate(requestParameters: EpisodeTournamentInitializeCreateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
+        await this.episodeTournamentInitializeCreateRaw(requestParameters, initOverrides);
+    }
+
+    /**
      * A viewset for retrieving Tournaments.
      */
     async episodeTournamentListRaw(requestParameters: EpisodeTournamentListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<PaginatedTournamentList>> {
@@ -419,6 +481,71 @@ export class EpisodeApi extends runtime.BaseAPI {
     }
 
     /**
+     * Enqueue the given round of the tournament. Fails if this round is already in progress.
+     */
+    async episodeTournamentRoundEnqueueCreateRaw(requestParameters: EpisodeTournamentRoundEnqueueCreateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
+        if (requestParameters.episodeId === null || requestParameters.episodeId === undefined) {
+            throw new runtime.RequiredError('episodeId','Required parameter requestParameters.episodeId was null or undefined when calling episodeTournamentRoundEnqueueCreate.');
+        }
+
+        if (requestParameters.id === null || requestParameters.id === undefined) {
+            throw new runtime.RequiredError('id','Required parameter requestParameters.id was null or undefined when calling episodeTournamentRoundEnqueueCreate.');
+        }
+
+        if (requestParameters.maps === null || requestParameters.maps === undefined) {
+            throw new runtime.RequiredError('maps','Required parameter requestParameters.maps was null or undefined when calling episodeTournamentRoundEnqueueCreate.');
+        }
+
+        if (requestParameters.tournament === null || requestParameters.tournament === undefined) {
+            throw new runtime.RequiredError('tournament','Required parameter requestParameters.tournament was null or undefined when calling episodeTournamentRoundEnqueueCreate.');
+        }
+
+        const queryParameters: any = {};
+
+        if (requestParameters.episodeId2 !== undefined) {
+            queryParameters['episode_id'] = requestParameters.episodeId2;
+        }
+
+        if (requestParameters.id2 !== undefined) {
+            queryParameters['id'] = requestParameters.id2;
+        }
+
+        if (requestParameters.maps) {
+            queryParameters['maps'] = requestParameters.maps;
+        }
+
+        if (requestParameters.tournament2 !== undefined) {
+            queryParameters['tournament'] = requestParameters.tournament2;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            const token = this.configuration.accessToken;
+            const tokenString = await token("jwtAuth", []);
+
+            if (tokenString) {
+                headerParameters["Authorization"] = `Bearer ${tokenString}`;
+            }
+        }
+        const response = await this.request({
+            path: `/api/episode/{episode_id}/tournament/{tournament}/round/{id}/enqueue/`.replace(`{${"episode_id"}}`, encodeURIComponent(String(requestParameters.episodeId))).replace(`{${"id"}}`, encodeURIComponent(String(requestParameters.id))).replace(`{${"tournament"}}`, encodeURIComponent(String(requestParameters.tournament))),
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     * Enqueue the given round of the tournament. Fails if this round is already in progress.
+     */
+    async episodeTournamentRoundEnqueueCreate(requestParameters: EpisodeTournamentRoundEnqueueCreateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
+        await this.episodeTournamentRoundEnqueueCreateRaw(requestParameters, initOverrides);
+    }
+
+    /**
      * A viewset for retrieving tournament rounds.
      */
     async episodeTournamentRoundListRaw(requestParameters: EpisodeTournamentRoundListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<PaginatedTournamentRoundList>> {
@@ -462,6 +589,51 @@ export class EpisodeApi extends runtime.BaseAPI {
     async episodeTournamentRoundList(requestParameters: EpisodeTournamentRoundListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<PaginatedTournamentRoundList> {
         const response = await this.episodeTournamentRoundListRaw(requestParameters, initOverrides);
         return await response.value();
+    }
+
+    /**
+     * Release the results of this round to the public bracket service.
+     */
+    async episodeTournamentRoundReleaseCreateRaw(requestParameters: EpisodeTournamentRoundReleaseCreateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
+        if (requestParameters.episodeId === null || requestParameters.episodeId === undefined) {
+            throw new runtime.RequiredError('episodeId','Required parameter requestParameters.episodeId was null or undefined when calling episodeTournamentRoundReleaseCreate.');
+        }
+
+        if (requestParameters.id === null || requestParameters.id === undefined) {
+            throw new runtime.RequiredError('id','Required parameter requestParameters.id was null or undefined when calling episodeTournamentRoundReleaseCreate.');
+        }
+
+        if (requestParameters.tournament === null || requestParameters.tournament === undefined) {
+            throw new runtime.RequiredError('tournament','Required parameter requestParameters.tournament was null or undefined when calling episodeTournamentRoundReleaseCreate.');
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            const token = this.configuration.accessToken;
+            const tokenString = await token("jwtAuth", []);
+
+            if (tokenString) {
+                headerParameters["Authorization"] = `Bearer ${tokenString}`;
+            }
+        }
+        const response = await this.request({
+            path: `/api/episode/{episode_id}/tournament/{tournament}/round/{id}/release/`.replace(`{${"episode_id"}}`, encodeURIComponent(String(requestParameters.episodeId))).replace(`{${"id"}}`, encodeURIComponent(String(requestParameters.id))).replace(`{${"tournament"}}`, encodeURIComponent(String(requestParameters.tournament))),
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     * Release the results of this round to the public bracket service.
+     */
+    async episodeTournamentRoundReleaseCreate(requestParameters: EpisodeTournamentRoundReleaseCreateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
+        await this.episodeTournamentRoundReleaseCreateRaw(requestParameters, initOverrides);
     }
 
     /**

--- a/frontend/src/api/_autogen/apis/EpisodeApi.ts
+++ b/frontend/src/api/_autogen/apis/EpisodeApi.ts
@@ -104,6 +104,15 @@ export interface EpisodeTournamentRoundReleaseCreateRequest {
     episodeId: string;
     id: string;
     tournament: string;
+    episodeId2?: string;
+    id2?: string;
+    tournament2?: string;
+}
+
+export interface EpisodeTournamentRoundRequeueCreateRequest {
+    episodeId: string;
+    id: string;
+    tournament: string;
 }
 
 export interface EpisodeTournamentRoundRetrieveRequest {
@@ -609,6 +618,18 @@ export class EpisodeApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
+        if (requestParameters.episodeId2 !== undefined) {
+            queryParameters['episode_id'] = requestParameters.episodeId2;
+        }
+
+        if (requestParameters.id2 !== undefined) {
+            queryParameters['id'] = requestParameters.id2;
+        }
+
+        if (requestParameters.tournament2 !== undefined) {
+            queryParameters['tournament'] = requestParameters.tournament2;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         if (this.configuration && this.configuration.accessToken) {
@@ -634,6 +655,51 @@ export class EpisodeApi extends runtime.BaseAPI {
      */
     async episodeTournamentRoundReleaseCreate(requestParameters: EpisodeTournamentRoundReleaseCreateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
         await this.episodeTournamentRoundReleaseCreateRaw(requestParameters, initOverrides);
+    }
+
+    /**
+     * Re-queue every unsuccessful match in this round on Saturn.
+     */
+    async episodeTournamentRoundRequeueCreateRaw(requestParameters: EpisodeTournamentRoundRequeueCreateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
+        if (requestParameters.episodeId === null || requestParameters.episodeId === undefined) {
+            throw new runtime.RequiredError('episodeId','Required parameter requestParameters.episodeId was null or undefined when calling episodeTournamentRoundRequeueCreate.');
+        }
+
+        if (requestParameters.id === null || requestParameters.id === undefined) {
+            throw new runtime.RequiredError('id','Required parameter requestParameters.id was null or undefined when calling episodeTournamentRoundRequeueCreate.');
+        }
+
+        if (requestParameters.tournament === null || requestParameters.tournament === undefined) {
+            throw new runtime.RequiredError('tournament','Required parameter requestParameters.tournament was null or undefined when calling episodeTournamentRoundRequeueCreate.');
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            const token = this.configuration.accessToken;
+            const tokenString = await token("jwtAuth", []);
+
+            if (tokenString) {
+                headerParameters["Authorization"] = `Bearer ${tokenString}`;
+            }
+        }
+        const response = await this.request({
+            path: `/api/episode/{episode_id}/tournament/{tournament}/round/{id}/requeue/`.replace(`{${"episode_id"}}`, encodeURIComponent(String(requestParameters.episodeId))).replace(`{${"id"}}`, encodeURIComponent(String(requestParameters.id))).replace(`{${"tournament"}}`, encodeURIComponent(String(requestParameters.tournament))),
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     * Re-queue every unsuccessful match in this round on Saturn.
+     */
+    async episodeTournamentRoundRequeueCreate(requestParameters: EpisodeTournamentRoundRequeueCreateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
+        await this.episodeTournamentRoundRequeueCreateRaw(requestParameters, initOverrides);
     }
 
     /**

--- a/frontend/src/api/_autogen/models/TournamentRound.ts
+++ b/frontend/src/api/_autogen/models/TournamentRound.ts
@@ -68,6 +68,12 @@ export interface TournamentRound {
      * @memberof TournamentRound
      */
     display_order: number;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof TournamentRound
+     */
+    in_progress?: boolean;
 }
 
 /**
@@ -100,6 +106,7 @@ export function TournamentRoundFromJSONTyped(json: any, ignoreDiscriminator: boo
         'maps': !exists(json, 'maps') ? undefined : json['maps'],
         'release_status': !exists(json, 'release_status') ? undefined : ReleaseStatusEnumFromJSON(json['release_status']),
         'display_order': json['display_order'],
+        'in_progress': !exists(json, 'in_progress') ? undefined : json['in_progress'],
     };
 }
 
@@ -118,6 +125,7 @@ export function TournamentRoundToJSON(value?: TournamentRound | null): any {
         'maps': value.maps,
         'release_status': ReleaseStatusEnumToJSON(value.release_status),
         'display_order': value.display_order,
+        'in_progress': value.in_progress,
     };
 }
 

--- a/frontend/src/api/episode/episodeApi.ts
+++ b/frontend/src/api/episode/episodeApi.ts
@@ -18,6 +18,7 @@ import {
   type EpisodeTournamentRoundReleaseCreateRequest,
   type EpisodeTournamentRoundRetrieveRequest,
   type TournamentRound,
+  type EpisodeTournamentRoundRequeueCreateRequest,
 } from "../_autogen";
 import { DEFAULT_API_CONFIGURATION } from "../helpers";
 
@@ -106,12 +107,14 @@ export const getTournamentRoundInfo = async ({
  * Get the rounds of a specific tournament during the given episode.
  * @param episodeId The current episode's ID.
  * @param tournament The tournament's ID.
+ * @param page The desired page to retrieve.
  */
 export const getTournamentRoundList = async ({
   episodeId,
   tournament,
+  page,
 }: EpisodeTournamentRoundListRequest): Promise<PaginatedTournamentRoundList> =>
-  await API.episodeTournamentRoundList({ episodeId, tournament });
+  await API.episodeTournamentRoundList({ episodeId, tournament, page });
 
 /**
  * Initialize the requested tournament id the given episode.
@@ -151,4 +154,15 @@ export const releaseTournamentRound = async ({
   id,
 }: EpisodeTournamentRoundReleaseCreateRequest): Promise<void> => {
   await API.episodeTournamentRoundReleaseCreate({ episodeId, tournament, id });
+};
+
+/**
+ * Asynchronously requeue the given tournament round's failed matches on Saturn.
+ */
+export const requeueTournamentRound = async ({
+  episodeId,
+  tournament,
+  id,
+}: EpisodeTournamentRoundRequeueCreateRequest): Promise<void> => {
+  await API.episodeTournamentRoundRequeueCreate({ episodeId, tournament, id });
 };

--- a/frontend/src/api/episode/episodeApi.ts
+++ b/frontend/src/api/episode/episodeApi.ts
@@ -11,6 +11,13 @@ import {
   type EpisodeTournamentListRequest,
   type EpisodeTournamentRetrieveRequest,
   type EpisodeEListRequest,
+  type EpisodeTournamentRoundListRequest,
+  type EpisodeTournamentInitializeCreateRequest,
+  type PaginatedTournamentRoundList,
+  type EpisodeTournamentRoundEnqueueCreateRequest,
+  type EpisodeTournamentRoundReleaseCreateRequest,
+  type EpisodeTournamentRoundRetrieveRequest,
+  type TournamentRound,
 } from "../_autogen";
 import { DEFAULT_API_CONFIGURATION } from "../helpers";
 
@@ -77,3 +84,71 @@ export const getTournamentInfo = async ({
     episodeId,
     id,
   });
+
+/**
+ * Get the information of a specific tournament round during the given episode.
+ * @param episodeId The current episode's ID.
+ * @param tournament The tournament's ID.
+ * @param id The round's ID.
+ */
+export const getTournamentRoundInfo = async ({
+  episodeId,
+  tournament,
+  id,
+}: EpisodeTournamentRoundRetrieveRequest): Promise<TournamentRound> =>
+  await API.episodeTournamentRoundRetrieve({
+    episodeId,
+    tournament,
+    id,
+  });
+
+/**
+ * Get the rounds of a specific tournament during the given episode.
+ * @param episodeId The current episode's ID.
+ * @param tournament The tournament's ID.
+ */
+export const getTournamentRoundList = async ({
+  episodeId,
+  tournament,
+}: EpisodeTournamentRoundListRequest): Promise<PaginatedTournamentRoundList> =>
+  await API.episodeTournamentRoundList({ episodeId, tournament });
+
+/**
+ * Initialize the requested tournament id the given episode.
+ * @param episodeId The current episode's ID.
+ * @param id The tournament's ID.
+ */
+export const initializeTournament = async ({
+  episodeId,
+  id,
+}: EpisodeTournamentInitializeCreateRequest): Promise<void> => {
+  await API.episodeTournamentInitializeCreate({ episodeId, id });
+};
+
+/**
+ * Create and enqueue matches for the given tournament round.
+ */
+export const createAndEnqueueMatches = async ({
+  episodeId,
+  tournament,
+  id,
+  maps,
+}: EpisodeTournamentRoundEnqueueCreateRequest): Promise<void> => {
+  await API.episodeTournamentRoundEnqueueCreate({
+    episodeId,
+    tournament,
+    id,
+    maps,
+  });
+};
+
+/**
+ * Asynchronously release the given tournament round to the bracket service.
+ */
+export const releaseTournamentRound = async ({
+  episodeId,
+  tournament,
+  id,
+}: EpisodeTournamentRoundReleaseCreateRequest): Promise<void> => {
+  await API.episodeTournamentRoundReleaseCreate({ episodeId, tournament, id });
+};

--- a/frontend/src/api/episode/episodeFactories.ts
+++ b/frontend/src/api/episode/episodeFactories.ts
@@ -6,11 +6,15 @@ import type {
   EpisodeTournamentListRequest,
   EpisodeTournamentNextRetrieveRequest,
   EpisodeTournamentRetrieveRequest,
+  EpisodeTournamentRoundListRequest,
+  EpisodeTournamentRoundRetrieveRequest,
   GameMap,
   PaginatedEpisodeList,
   PaginatedTournamentList,
+  PaginatedTournamentRoundList,
   ResponseError,
   Tournament,
+  TournamentRound,
 } from "../_autogen";
 import {
   HttpStatusCode,
@@ -25,6 +29,8 @@ import {
   getNextTournament,
   getTournamentInfo,
   getTournamentList,
+  getTournamentRoundInfo,
+  getTournamentRoundList,
 } from "./episodeApi";
 import { episodeQueryKeys } from "./episodeKeys";
 
@@ -118,3 +124,36 @@ export const tournamentInfoFactory: QueryFactory<
   queryFn: async ({ episodeId, id }) =>
     await getTournamentInfo({ episodeId, id }),
 } as const;
+
+export const tournamentRoundInfoFactory: QueryFactory<
+  EpisodeTournamentRoundRetrieveRequest,
+  TournamentRound
+> = {
+  queryKey: episodeQueryKeys.tournamentRoundInfo,
+  queryFn: async ({ episodeId, tournament, id }) =>
+    await getTournamentRoundInfo({ episodeId, tournament, id }),
+} as const;
+
+export const tournamentRoundListFactory: PaginatedQueryFactory<
+  EpisodeTournamentRoundListRequest,
+  PaginatedTournamentRoundList
+> = {
+  queryKey: episodeQueryKeys.tournamentRoundList,
+  queryFn: async (request, queryClient, prefetchNext) => {
+    const result = await getTournamentRoundList(request);
+    // Prefetch the next page if we want to prefetch
+    if (prefetchNext) {
+      await prefetchNextPage(
+        request,
+        result,
+        {
+          queryKey: episodeQueryKeys.tournamentRoundList,
+          queryFn: tournamentRoundListFactory.queryFn,
+        },
+        queryClient,
+      );
+    }
+
+    return result;
+  },
+};

--- a/frontend/src/api/episode/episodeKeys.ts
+++ b/frontend/src/api/episode/episodeKeys.ts
@@ -9,6 +9,7 @@ import type {
   EpisodeTournamentRoundEnqueueCreateRequest,
   EpisodeTournamentRoundListRequest,
   EpisodeTournamentRoundReleaseCreateRequest,
+  EpisodeTournamentRoundRequeueCreateRequest,
   EpisodeTournamentRoundRetrieveRequest,
 } from "../_autogen";
 import type { QueryKeyBuilder } from "../apiTypes";
@@ -147,5 +148,20 @@ export const episodeMutationKeys = {
       "round",
       id,
       "release",
+    ] as const,
+
+  requeueTournamentRound: ({
+    episodeId,
+    tournament,
+    id,
+  }: EpisodeTournamentRoundRequeueCreateRequest) =>
+    [
+      "episode",
+      episodeId,
+      "tournament",
+      tournament,
+      "round",
+      id,
+      "requeue",
     ] as const,
 };

--- a/frontend/src/api/episode/episodeKeys.ts
+++ b/frontend/src/api/episode/episodeKeys.ts
@@ -2,9 +2,14 @@ import type {
   EpisodeEListRequest,
   EpisodeERetrieveRequest,
   EpisodeMapListRequest,
+  EpisodeTournamentInitializeCreateRequest,
   EpisodeTournamentListRequest,
   EpisodeTournamentNextRetrieveRequest,
   EpisodeTournamentRetrieveRequest,
+  EpisodeTournamentRoundEnqueueCreateRequest,
+  EpisodeTournamentRoundListRequest,
+  EpisodeTournamentRoundReleaseCreateRequest,
+  EpisodeTournamentRoundRetrieveRequest,
 } from "../_autogen";
 import type { QueryKeyBuilder } from "../apiTypes";
 
@@ -15,7 +20,10 @@ interface EpisodeKeys {
   maps: QueryKeyBuilder<EpisodeMapListRequest>;
   tournamentList: QueryKeyBuilder<EpisodeTournamentListRequest>;
   nextTournament: QueryKeyBuilder<EpisodeTournamentNextRetrieveRequest>;
+  tournamentBase: QueryKeyBuilder<{ episodeId: string; id: string }>;
   tournamentInfo: QueryKeyBuilder<EpisodeTournamentRetrieveRequest>;
+  tournamentRoundInfo: QueryKeyBuilder<EpisodeTournamentRoundRetrieveRequest>;
+  tournamentRoundList: QueryKeyBuilder<EpisodeTournamentRoundListRequest>;
 }
 
 // ---------- QUERY KEYS ---------- //
@@ -56,12 +64,88 @@ export const episodeQueryKeys: EpisodeKeys = {
       ] as const,
   },
 
-  tournamentInfo: {
-    key: ({ episodeId, id }: EpisodeTournamentRetrieveRequest) =>
+  tournamentBase: {
+    key: ({ episodeId, id }: { episodeId: string; id: string }) =>
       [
         ...episodeQueryKeys.byId.key({ id: episodeId }),
-        "tournamentInfo",
+        "tournament",
         id,
       ] as const,
   },
+
+  tournamentInfo: {
+    key: ({ episodeId, id }: EpisodeTournamentRetrieveRequest) =>
+      [
+        ...episodeQueryKeys.tournamentBase.key({ episodeId, id }),
+        "info",
+        id,
+      ] as const,
+  },
+
+  tournamentRoundInfo: {
+    key: ({
+      episodeId,
+      tournament,
+      id,
+    }: EpisodeTournamentRoundRetrieveRequest) =>
+      [
+        ...episodeQueryKeys.tournamentBase.key({ episodeId, id: tournament }),
+        "round",
+        id,
+      ] as const,
+  },
+
+  tournamentRoundList: {
+    key: ({
+      episodeId,
+      tournament,
+      page = 1,
+    }: EpisodeTournamentRoundListRequest) =>
+      [
+        ...episodeQueryKeys.tournamentBase.key({ episodeId, id: tournament }),
+        "round",
+        "list",
+        page,
+      ] as const,
+  },
+};
+
+// ---------- MUTATION KEYS ---------- //
+export const episodeMutationKeys = {
+  initializeTournament: ({
+    episodeId,
+    id,
+  }: EpisodeTournamentInitializeCreateRequest) =>
+    ["episode", episodeId, "tournament", id, "initialize"] as const,
+
+  // We don't include the maps because they aren't relevant to the key
+  createEnqueueTournamentRound: ({
+    episodeId,
+    tournament,
+    id,
+  }: EpisodeTournamentRoundEnqueueCreateRequest) =>
+    [
+      "episode",
+      episodeId,
+      "tournament",
+      tournament,
+      "round",
+      id,
+      "createEnqueue",
+    ] as const,
+
+  releaseTournamentRound: ({
+    episodeId,
+    tournament,
+    id,
+  }: EpisodeTournamentRoundReleaseCreateRequest) =>
+    [
+      "episode",
+      episodeId,
+      "tournament",
+      tournament,
+      "round",
+      id,
+      "release",
+    ] as const,
 };

--- a/frontend/src/api/episode/useEpisode.ts
+++ b/frontend/src/api/episode/useEpisode.ts
@@ -2,19 +2,29 @@ import {
   type UseQueryResult,
   useQuery,
   type QueryClient,
+  useMutation,
+  type UseMutationResult,
 } from "@tanstack/react-query";
 import type {
   Episode,
   EpisodeEListRequest,
   EpisodeERetrieveRequest,
   EpisodeMapListRequest,
+  EpisodeTournamentInitializeCreateRequest,
   EpisodeTournamentListRequest,
   EpisodeTournamentNextRetrieveRequest,
   EpisodeTournamentRetrieveRequest,
+  EpisodeTournamentRoundEnqueueCreateRequest,
+  EpisodeTournamentRoundListRequest,
+  EpisodeTournamentRoundReleaseCreateRequest,
+  EpisodeTournamentRoundRetrieveRequest,
   GameMap,
   PaginatedEpisodeList,
   PaginatedTournamentList,
+  PaginatedTournamentRoundList,
+  ResponseError,
   Tournament,
+  TournamentRound,
 } from "../_autogen";
 import { buildKey } from "../helpers";
 import {
@@ -24,8 +34,17 @@ import {
   nextTournamentFactory,
   tournamentInfoFactory,
   tournamentListFactory,
+  tournamentRoundInfoFactory,
+  tournamentRoundListFactory,
 } from "./episodeFactories";
 import { MILLIS_SECOND, SECONDS_MINUTE } from "utils/utilTypes";
+import { episodeMutationKeys, episodeQueryKeys } from "./episodeKeys";
+import {
+  createAndEnqueueMatches,
+  initializeTournament,
+  releaseTournamentRound,
+} from "./episodeApi";
+import toast from "react-hot-toast";
 
 // ---------- QUERY HOOKS ---------- //
 const EPISODE_WAIT_TIME = 5;
@@ -105,4 +124,198 @@ export const useTournamentInfo = ({
   useQuery({
     queryKey: buildKey(tournamentInfoFactory.queryKey, { episodeId, id }),
     queryFn: async () => await tournamentInfoFactory.queryFn({ episodeId, id }),
+  });
+
+/**
+ * For retrieving the information of a specific tournament round occurring during the given episode.
+ */
+export const useTournamentRoundInfo = ({
+  episodeId,
+  tournament,
+  id,
+}: EpisodeTournamentRoundRetrieveRequest): UseQueryResult<TournamentRound> =>
+  useQuery({
+    queryKey: buildKey(tournamentRoundInfoFactory.queryKey, {
+      episodeId,
+      tournament,
+      id,
+    }),
+    queryFn: async () =>
+      await tournamentRoundInfoFactory.queryFn({ episodeId, tournament, id }),
+  });
+
+/**
+ * For retrieving a list of the rounds in a specific tournament occurring during the given episode.
+ */
+export const useTournamentRoundList = (
+  { episodeId, tournament }: EpisodeTournamentRoundListRequest,
+  queryClient: QueryClient,
+): UseQueryResult<PaginatedTournamentRoundList> =>
+  useQuery({
+    queryKey: buildKey(tournamentRoundListFactory.queryKey, {
+      episodeId,
+      tournament,
+    }),
+    queryFn: async () =>
+      await tournamentRoundListFactory.queryFn(
+        { episodeId, tournament },
+        queryClient,
+        true,
+      ),
+  });
+
+// ---------- MUTATION HOOKS ---------- //
+/**
+ * For initializing the given tournament in the given episode.
+ */
+export const useInitializeTournament = (
+  { episodeId, id }: EpisodeTournamentInitializeCreateRequest,
+  queryClient: QueryClient,
+): UseMutationResult<void, Error, EpisodeTournamentInitializeCreateRequest> =>
+  useMutation({
+    mutationKey: episodeMutationKeys.initializeTournament({ episodeId, id }),
+    mutationFn: async ({
+      episodeId,
+      id,
+    }: EpisodeTournamentInitializeCreateRequest) => {
+      const toastFn = async (): Promise<void> => {
+        await initializeTournament({ episodeId, id });
+
+        // Refetch all info for this tournament
+        try {
+          // Invalidate all queries for this tournament TODO verify this works!
+          const invalidateInfo = queryClient.invalidateQueries({
+            queryKey: buildKey(episodeQueryKeys.tournamentBase, {
+              episodeId,
+              id,
+            }),
+          });
+          const prefetchInfo = queryClient.prefetchQuery({
+            queryKey: buildKey(tournamentInfoFactory.queryKey, {
+              episodeId,
+              id,
+            }),
+            queryFn: async () =>
+              await tournamentInfoFactory.queryFn({ episodeId, id }),
+          });
+          const prefetchRounds = queryClient.prefetchQuery({
+            queryKey: buildKey(tournamentRoundListFactory.queryKey, {
+              episodeId,
+              tournament: id,
+              page: 1,
+            }),
+            queryFn: async () =>
+              await tournamentRoundListFactory.queryFn(
+                { episodeId, tournament: id, page: 1 },
+                queryClient,
+                true,
+              ),
+          });
+
+          await Promise.all([invalidateInfo, prefetchInfo, prefetchRounds]);
+        } catch (e) {
+          toast.error((e as ResponseError).message);
+        }
+      };
+
+      await toast.promise(toastFn(), {
+        loading: "Initializing tournament...",
+        success: "Tournament initialized!",
+        error: "Error initializing tournament.",
+      });
+    },
+  });
+
+/**
+ * For creating and enqueuing matches for the given tournament round.
+ */
+export const useCreateAndEnqueueMatches = (
+  { episodeId, tournament, id }: EpisodeTournamentRoundEnqueueCreateRequest,
+  queryClient: QueryClient,
+): UseMutationResult<void, Error, EpisodeTournamentRoundEnqueueCreateRequest> =>
+  useMutation({
+    mutationKey: episodeMutationKeys.createEnqueueTournamentRound({
+      episodeId,
+      tournament,
+      id,
+      maps: [], // the maps are not part of the key
+    }),
+    mutationFn: async ({
+      episodeId,
+      tournament,
+      id,
+      maps,
+    }: EpisodeTournamentRoundEnqueueCreateRequest) => {
+      const toastFn = async (): Promise<void> => {
+        await createAndEnqueueMatches({ episodeId, tournament, id, maps });
+
+        // Refetch this tournament's rounds
+        try {
+          const invalidateRounds = queryClient.invalidateQueries({
+            queryKey: buildKey(episodeQueryKeys.tournamentBase, {
+              episodeId,
+              id: tournament,
+            }),
+          });
+          const prefetchRounds = queryClient.prefetchQuery({
+            queryKey: buildKey(tournamentRoundListFactory.queryKey, {
+              episodeId,
+              tournament,
+              page: 1,
+            }),
+            queryFn: async () =>
+              await tournamentRoundListFactory.queryFn(
+                { episodeId, tournament, page: 1 },
+                queryClient,
+                true,
+              ),
+          });
+
+          await Promise.all([invalidateRounds, prefetchRounds]);
+        } catch (e) {
+          toast.error((e as ResponseError).message);
+        }
+      };
+
+      await toast.promise(toastFn(), {
+        loading: "Creating and enqueuing matches...",
+        success: "Matches created and enqueued!",
+        error: "Error creating and enqueuing matches.",
+      });
+    },
+  });
+
+/**
+ * For releasing the given tournament round to the bracket service.
+ */
+export const useReleaseTournamentRound = ({
+  episodeId,
+  tournament,
+  id,
+}: EpisodeTournamentRoundReleaseCreateRequest): UseMutationResult<
+  void,
+  Error,
+  EpisodeTournamentRoundReleaseCreateRequest
+> =>
+  useMutation({
+    mutationKey: episodeMutationKeys.releaseTournamentRound({
+      episodeId,
+      tournament,
+      id,
+    }),
+    mutationFn: async ({
+      episodeId,
+      tournament,
+      id,
+    }: EpisodeTournamentRoundReleaseCreateRequest) => {
+      const toastFn = async (): Promise<void> => {
+        await releaseTournamentRound({ episodeId, tournament, id });
+      };
+
+      await toast.promise(toastFn(), {
+        loading: "Initiating round release...",
+        success: "Round release initiated!",
+        error: "Error releasing tournament round.",
+      });
+    },
   });

--- a/frontend/src/api/helpers.ts
+++ b/frontend/src/api/helpers.ts
@@ -154,3 +154,7 @@ export const getClientUrl = (
       }`;
   }
 };
+
+export function classNames(...classes: string[]): string {
+  return classes.filter(Boolean).join(" ");
+}

--- a/frontend/src/api/loaders/adminTournamentLoader.ts
+++ b/frontend/src/api/loaders/adminTournamentLoader.ts
@@ -1,0 +1,27 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { buildKey } from "api/helpers";
+import { myUserInfoFactory } from "api/user/userFactories";
+import { type LoaderFunction, redirect } from "react-router-dom";
+
+export const adminTournamentLoader =
+  (queryClient: QueryClient): LoaderFunction =>
+  async ({ params }) => {
+    const { episodeId, tournamentId } = params;
+    if (episodeId === undefined) return null;
+    if (tournamentId === undefined) return redirect(`/${episodeId}/home`);
+
+    // Ensure the user is a staff member
+    const user = queryClient.ensureQueryData({
+      queryKey: buildKey(myUserInfoFactory.queryKey, {}),
+      queryFn: async () => await myUserInfoFactory.queryFn({}),
+    });
+
+    try {
+      if (!(await user).is_staff)
+        return redirect(`/${episodeId}/tournament/${tournamentId}`);
+    } catch (_) {
+      return redirect(`/${episodeId}/tournament/${tournamentId}`);
+    }
+
+    return null;
+  };

--- a/frontend/src/components/elements/Icon.tsx
+++ b/frontend/src/components/elements/Icon.tsx
@@ -28,6 +28,7 @@ import {
   ShareIcon as ShareIcon24,
   LockClosedIcon as LockClosedIcon24,
   ExclamationTriangleIcon as ExclamationTriangleIcon24,
+  ArrowPathIcon as ArrowPathIcon24,
 } from "@heroicons/react/24/outline";
 
 import {
@@ -59,6 +60,7 @@ import {
   ShareIcon as ShareIcon20,
   LockClosedIcon as LockClosedIcon20,
   ExclamationTriangleIcon as ExclamationTriangleIcon20,
+  ArrowPathIcon as ArrowPathIcon20,
 } from "@heroicons/react/20/solid";
 
 const icons24 = {
@@ -90,6 +92,7 @@ const icons24 = {
   share: ShareIcon24,
   lock_closed: LockClosedIcon24,
   exclamation_triangle: ExclamationTriangleIcon24,
+  arrow_path: ArrowPathIcon24,
 };
 
 const icons20 = {
@@ -121,6 +124,7 @@ const icons20 = {
   share: ShareIcon20,
   lock_closed: LockClosedIcon20,
   exclamation_triangle: ExclamationTriangleIcon20,
+  arrow_path: ArrowPathIcon20,
 };
 
 export type IconName = keyof typeof icons24;

--- a/frontend/src/components/elements/Icon.tsx
+++ b/frontend/src/components/elements/Icon.tsx
@@ -25,6 +25,9 @@ import {
   UserCircleIcon as UserCircleIcon24,
   UserPlusIcon as UserPlusIcon24,
   FunnelIcon as FilterIcon24,
+  ShareIcon as ShareIcon24,
+  LockClosedIcon as LockClosedIcon24,
+  ExclamationTriangleIcon as ExclamationTriangleIcon24,
 } from "@heroicons/react/24/outline";
 
 import {
@@ -53,6 +56,9 @@ import {
   UserCircleIcon as UserCircleIcon20,
   UserPlusIcon as UserPlusIcon20,
   FunnelIcon as FilterIcon20,
+  ShareIcon as ShareIcon20,
+  LockClosedIcon as LockClosedIcon20,
+  ExclamationTriangleIcon as ExclamationTriangleIcon20,
 } from "@heroicons/react/20/solid";
 
 const icons24 = {
@@ -81,6 +87,9 @@ const icons24 = {
   user_circle: UserCircleIcon24,
   user_plus: UserPlusIcon24,
   filter: FilterIcon24,
+  share: ShareIcon24,
+  lock_closed: LockClosedIcon24,
+  exclamation_triangle: ExclamationTriangleIcon24,
 };
 
 const icons20 = {
@@ -109,6 +118,9 @@ const icons20 = {
   user_circle: UserCircleIcon20,
   user_plus: UserPlusIcon20,
   filter: FilterIcon20,
+  share: ShareIcon20,
+  lock_closed: LockClosedIcon20,
+  exclamation_triangle: ExclamationTriangleIcon20,
 };
 
 export type IconName = keyof typeof icons24;

--- a/frontend/src/components/elements/SelectMultipleMenu.tsx
+++ b/frontend/src/components/elements/SelectMultipleMenu.tsx
@@ -101,12 +101,13 @@ function SelectMultipleMenu<T extends React.Key | null | undefined>({
                   key={option.value}
                   value={option.value}
                 >
-                  <div className="w-full overflow-x-auto pr-2">
-                    {option.label}
-                  </div>
-                  <span className="hidden items-center text-cyan-900 ui-selected:flex">
-                    <Icon name="check" size="sm" />
-                  </span>
+                  <div className="overflow-x-auto pr-2">{option.label}</div>
+                  {value !== undefined &&
+                    value.some((opt) => opt === option.value) && (
+                      <span className="hidden items-center text-cyan-900 ui-selected:flex">
+                        <Icon name="check" size="sm" />
+                      </span>
+                    )}
                 </Listbox.Option>
               ))}
             </Listbox.Options>

--- a/frontend/src/components/tables/TournamentsTable.tsx
+++ b/frontend/src/components/tables/TournamentsTable.tsx
@@ -1,12 +1,14 @@
 import type React from "react";
 import { useNavigate } from "react-router-dom";
 import { useEpisodeId } from "../../contexts/EpisodeContext";
-import type { PaginatedTournamentList } from "../../api/_autogen";
+import type { PaginatedTournamentList, Tournament } from "../../api/_autogen";
 import type { Maybe } from "../../utils/utilTypes";
-import Table from "../Table";
+import Table, { type Column } from "../Table";
 import TableBottom from "../TableBottom";
 import { dateTime } from "../../utils/dateTime";
 import Icon from "../elements/Icon";
+import { useCurrentUser } from "contexts/CurrentUserContext";
+import Button from "components/elements/Button";
 
 interface TournamentsTableProps {
   data: Maybe<PaginatedTournamentList>;
@@ -23,6 +25,23 @@ const TournamentsTable: React.FC<TournamentsTableProps> = ({
 }) => {
   const { episodeId } = useEpisodeId();
   const navigate = useNavigate();
+
+  const { user } = useCurrentUser();
+
+  const adminColumn: Column<Tournament> = {
+    header: "Admin",
+    key: "admin",
+    value: (tour) => (
+      <Button
+        variant="dark"
+        label="Go!"
+        onClick={(ev) => {
+          ev.stopPropagation();
+          navigate(`/${episodeId}/tournament/${tour.name_short}/admin`);
+        }}
+      />
+    ),
+  };
 
   return (
     <Table
@@ -64,6 +83,7 @@ const TournamentsTable: React.FC<TournamentsTableProps> = ({
               <Icon name={"x_mark"} className="text-red-700" size="md" />
             ),
         },
+        ...(user.isSuccess && user.data.is_staff ? [adminColumn] : []),
         {
           header: "About",
           key: "blurb",

--- a/frontend/src/views/AdminTournament.tsx
+++ b/frontend/src/views/AdminTournament.tsx
@@ -1,0 +1,422 @@
+import { Tab } from "@headlessui/react";
+import { type QueryClient, useQueryClient } from "@tanstack/react-query";
+import {
+  ReleaseStatusEnum,
+  StatusBccEnum,
+  type TournamentRound,
+} from "api/_autogen";
+import { useTournamentMatchList } from "api/compete/useCompete";
+import {
+  useCreateAndEnqueueMatches,
+  useEpisodeInfo,
+  useEpisodeMaps,
+  useInitializeTournament,
+  useReleaseTournamentRound,
+  useTournamentInfo,
+  useTournamentRoundInfo,
+  useTournamentRoundList,
+} from "api/episode/useEpisode";
+import { buildKey, classNames } from "api/helpers";
+import { myUserInfoFactory } from "api/user/userFactories";
+import { PageTitle } from "components/elements/BattlecodeStyle";
+import Button from "components/elements/Button";
+import Icon from "components/elements/Icon";
+import SelectMultipleMenu from "components/elements/SelectMultipleMenu";
+import Tooltip from "components/elements/Tooltip";
+import Modal from "components/Modal";
+import SectionCard from "components/SectionCard";
+import Spinner from "components/Spinner";
+import TournamentResultsTable from "components/tables/TournamentResultsTable";
+import { useEpisodeId } from "contexts/EpisodeContext";
+import type React from "react";
+import { useCallback, useMemo, useState } from "react";
+import { type LoaderFunction, redirect, useParams } from "react-router-dom";
+import { isPresent } from "utils/utilTypes";
+
+export const adminTournamentLoader =
+  (queryClient: QueryClient): LoaderFunction =>
+  async ({ params }) => {
+    const { episodeId, tournamentId } = params;
+    if (episodeId === undefined) return null;
+    if (tournamentId === undefined) return redirect(`/${episodeId}/home`);
+
+    // Ensure the user is a staff member
+    const user = queryClient.ensureQueryData({
+      queryKey: buildKey(myUserInfoFactory.queryKey, {}),
+      queryFn: myUserInfoFactory.queryFn,
+    });
+
+    if (!(await user).is_staff)
+      return redirect(`/${episodeId}/tournament/${tournamentId}`);
+
+    return null;
+  };
+
+const AdminTournament: React.FC = () => {
+  const { episodeId } = useEpisodeId();
+  const { tournamentId } = useParams();
+
+  const queryClient = useQueryClient();
+
+  const tournament = useTournamentInfo({
+    episodeId,
+    id: tournamentId ?? "",
+  });
+  const tournamentRounds = useTournamentRoundList(
+    {
+      episodeId,
+      tournament: tournamentId ?? "",
+    },
+    queryClient,
+  );
+
+  const initializeTournament = useInitializeTournament(
+    { episodeId, id: tournamentId ?? "" },
+    queryClient,
+  );
+
+  const [initializeModalOpen, setInitializeModalOpen] = useState(false);
+
+  const LOADING = tournament.isLoading || tournamentRounds.isLoading;
+  const SUCCESS = tournament.isSuccess && tournamentRounds.isSuccess;
+
+  const TABLIST_STYLE = "flex space-x-1 rounded-xl bg-cyan-600 p-1";
+
+  const canInitialize = useMemo(() => {
+    if (LOADING || !SUCCESS) return false;
+
+    // We can only initialize if there are no rounds yet
+    return tournamentRounds.data.count === 0;
+  }, [tournament, tournamentRounds]);
+
+  const sortedRounds = useMemo(
+    () =>
+      tournamentRounds.data?.results?.sort(
+        (a, b) => a.display_order - b.display_order,
+      ) ?? [],
+    [tournamentRounds],
+  );
+
+  const activeRound = useMemo(() => {
+    if (LOADING || !SUCCESS) return undefined;
+
+    // First round which is still fully hidden
+    return sortedRounds.find(
+      (round) =>
+        !isPresent(round.release_status) ||
+        round.release_status < ReleaseStatusEnum.NUMBER_1,
+    );
+  }, [LOADING, SUCCESS, tournamentRounds]);
+
+  const canReset = useCallback(
+    (round: TournamentRound) => {
+      if (!isPresent(activeRound)) return false;
+
+      if (round.id === activeRound.id) return true;
+
+      // Can reset if is round before active
+      if (
+        round.display_order === activeRound.display_order - 1 &&
+        isPresent(activeRound.release_status) &&
+        activeRound.release_status > ReleaseStatusEnum.NUMBER_0
+      ) {
+        return true;
+      }
+
+      return false;
+    },
+    [activeRound],
+  );
+
+  return (
+    <div className="flex h-full w-full flex-col gap-4 p-6">
+      <PageTitle>
+        Admin Settings{" "}
+        {tournament.isSuccess ? `for ${tournament.data.name_long}` : ""}
+      </PageTitle>
+
+      <Tooltip text="Creates bracket and spawns rounds.">
+        <Button
+          disabled={!canInitialize}
+          loading={LOADING}
+          label="Initialize!"
+          iconName={
+            (tournamentRounds.data?.count ?? 0) > 0 ? "check" : "play_circle"
+          }
+          onClick={() => {
+            setInitializeModalOpen(true);
+          }}
+        />
+      </Tooltip>
+
+      <SectionCard title="Manage Rounds" loading={tournamentRounds.isLoading}>
+        {tournamentRounds.isSuccess && (
+          <Tab.Group>
+            <Tab.List className={TABLIST_STYLE}>
+              {sortedRounds.map((round) => (
+                <RoundTab
+                  key={round.id}
+                  tournamentId={round.tournament}
+                  roundId={round.id}
+                  activeRound={round.id === activeRound?.id}
+                  canReset={canReset(round)}
+                />
+              ))}
+            </Tab.List>
+            {sortedRounds.map((round) => (
+              <RoundPanel
+                key={round.id}
+                tournamentId={round.tournament}
+                roundId={round.id}
+                activeRound={round.id === activeRound?.id}
+                canReset={canReset(round)}
+              />
+            ))}
+          </Tab.Group>
+        )}
+      </SectionCard>
+
+      {/* TODO: link to client tournament display thingy? and/or iframe it */}
+      {/* TODO: link to challonge! */}
+      {/* TODO: Tournament rounds accessible via tabs? */}
+
+      <Modal
+        isOpen={initializeModalOpen}
+        closeModal={() => {
+          setInitializeModalOpen(false);
+        }}
+        title={`Initialize ${tournament.data?.name_long ?? ""}`}
+      >
+        <div className="mt-4 flex flex-col gap-4">
+          <span className="font-semibold text-gray-700">
+            Are you sure you want to initialize this tournament? Initializing
+            will seed the tournament with eligible teams in order of decreasing
+            rating, populate the brackets in the bracket service, and create
+            tournament rounds.
+          </span>
+          <div className="mt-2 flex flex-row gap-4">
+            <Button
+              label="Confirm"
+              variant="dark"
+              fullWidth
+              loading={initializeTournament.isPending}
+              onClick={() => {
+                initializeTournament.mutate({
+                  episodeId,
+                  id: tournamentId ?? "",
+                });
+                setInitializeModalOpen(false);
+              }}
+            />
+            <Button
+              fullWidth
+              label="Cancel"
+              onClick={() => {
+                setInitializeModalOpen(false);
+              }}
+            />
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+interface RoundTabProps {
+  tournamentId: string;
+  roundId: number;
+  activeRound: boolean;
+  canReset: boolean;
+}
+
+const RoundTab: React.FC<RoundTabProps> = ({
+  tournamentId,
+  roundId,
+  activeRound,
+  canReset,
+}) => {
+  const { episodeId } = useEpisodeId();
+
+  const round = useTournamentRoundInfo({
+    episodeId,
+    tournament: tournamentId,
+    id: roundId.toString(),
+  });
+
+  const tabClassName = useCallback(({ selected }: { selected: boolean }) => {
+    const classes = [
+      "w-full rounded-lg py-2.5 text-sm font-medium leading-5 min-w-10",
+      "ring-white/60 ring-offset-2 ring-offset-cyan-400 focus:outline-none focus:ring-2",
+    ];
+
+    if (selected) {
+      classes.push("bg-white text-cyan-700 shadow");
+    } else {
+      classes.push("text-cyan-100 hover:bg-white/[0.12] hover:text-white");
+    }
+
+    // TODO differential tab styling based on isActive and canReset
+
+    return classNames(...classes);
+  }, []);
+
+  return (
+    <Tab className={tabClassName}>
+      <div className="flex w-full flex-col items-center justify-center gap-2">
+        {round.data?.name ?? <Spinner size="sm" />}
+        {round.isSuccess && !canReset && <Icon size="sm" name="lock_closed" />}
+        {round.isSuccess && activeRound && (
+          <Icon size="sm" name="exclamation_triangle" />
+        )}
+      </div>
+    </Tab>
+  );
+};
+
+interface RoundPanelProps {
+  tournamentId: string;
+  roundId: number;
+  activeRound: boolean;
+  canReset: boolean;
+}
+
+const RoundPanel: React.FC<RoundPanelProps> = ({
+  tournamentId,
+  roundId,
+  activeRound,
+  canReset,
+}) => {
+  const { episodeId } = useEpisodeId();
+  const queryClient = useQueryClient();
+
+  const [selectedMaps, setSelectedMaps] = useState<number[]>([]);
+  const [matchesPage, setMatchesPage] = useState(1);
+
+  const episode = useEpisodeInfo({ id: episodeId });
+  const round = useTournamentRoundInfo({
+    episodeId,
+    tournament: tournamentId,
+    id: roundId.toString(),
+  });
+  const matches = useTournamentMatchList(
+    { episodeId, roundId, tournamentId },
+    queryClient,
+  );
+  const maps = useEpisodeMaps({ episodeId });
+
+  const createAndEnqueue = useCreateAndEnqueueMatches(
+    {
+      episodeId,
+      tournament: tournamentId,
+      id: roundId.toString(),
+      maps: selectedMaps,
+    },
+    queryClient,
+  );
+  const release = useReleaseTournamentRound({
+    episodeId,
+    tournament: tournamentId,
+    id: roundId.toString(),
+  });
+
+  const canCreateEnqueue = useMemo(() => {
+    if (!matches.isSuccess || !round.isSuccess) return false;
+
+    return (
+      activeRound &&
+      canReset &&
+      !(
+        matches.data.results?.some(
+          (match) =>
+            match.status === StatusBccEnum.New ||
+            match.status === StatusBccEnum.Que ||
+            match.status === StatusBccEnum.Run ||
+            match.status === StatusBccEnum.Try,
+        ) ?? false
+      )
+    );
+  }, [matches, round]);
+
+  // const canRelease = useMemo(() => {
+  //   // TODO: when can we release this round?
+  // }, []);
+
+  if (activeRound) {
+    console.log("round", round.data);
+  }
+
+  return (
+    <Tab.Panel className="flex flex-col gap-4 rounded-xl bg-white p-3 ring-white/60 ring-offset-2 ring-offset-cyan-400 focus:outline-none focus:ring-2">
+      <SelectMultipleMenu<number>
+        label="Select An Odd Number of Maps"
+        options={maps.data?.map((m) => ({ value: m.id, label: m.name })) ?? []}
+        placeholder={"Select maps for this round..."}
+        value={selectedMaps}
+        onChange={(newMaps) => {
+          setSelectedMaps(newMaps);
+        }}
+      />
+
+      <span className="font-normal text-gray-700">
+        {`This round is ${activeRound ? "active" : "not active"}. It ${
+          canReset ? "can" : "cannot"
+        } be reset.`}
+      </span>
+
+      <SectionCard title="Matches">
+        <div className="mb-4 flex flex-row gap-4">
+          <Tooltip text="If matches already exist, this will restart the round.">
+            <Button
+              // TODO: disable logic isn't correct yet
+              disabled={!canCreateEnqueue}
+              loading={createAndEnqueue.isPending}
+              iconName="play_circle"
+              variant="dark"
+              label="Create Matches"
+              onClick={() => {
+                createAndEnqueue.mutate({
+                  episodeId,
+                  tournament: tournamentId,
+                  id: roundId.toString(),
+                  maps: selectedMaps,
+                });
+              }}
+            />
+          </Tooltip>
+          <Tooltip text="Releases the round to the bracket service.">
+            <Button
+              // TODO: disable logic isn't correct yet
+              disabled={
+                !round.isSuccess ||
+                round.data.release_status !== ReleaseStatusEnum.NUMBER_2 // TODO what do release statuses mean??
+              }
+              loading={release.isPending}
+              iconName="share"
+              variant="dark"
+              label="Release Round"
+              onClick={() => {
+                release.mutate({
+                  episodeId,
+                  tournament: tournamentId,
+                  id: roundId.toString(),
+                });
+              }}
+            />
+          </Tooltip>
+        </div>
+
+        <TournamentResultsTable
+          data={matches.data}
+          loading={matches.isLoading}
+          page={matchesPage}
+          episode={episode}
+          handlePage={(newPage) => {
+            setMatchesPage(newPage);
+          }}
+        />
+      </SectionCard>
+    </Tab.Panel>
+  );
+};
+
+export default AdminTournament;

--- a/frontend/src/views/Scrimmaging.tsx
+++ b/frontend/src/views/Scrimmaging.tsx
@@ -13,6 +13,7 @@ import { useEpisodeId } from "contexts/EpisodeContext";
 import { useUserTeam } from "api/team/useTeam";
 import Spinner from "components/Spinner";
 import { PageTitle } from "components/elements/BattlecodeStyle";
+import { classNames } from "api/helpers";
 
 interface QueryParams {
   inboxPage: number;
@@ -26,10 +27,6 @@ interface QueryParams {
 const Scrimmaging: React.FC = () => {
   const { episodeId } = useEpisodeId();
   const userTeam = useUserTeam({ episodeId });
-
-  function classNames(...classes: string[]): string {
-    return classes.filter(Boolean).join(" ");
-  }
 
   const tabClassName = ({ selected }: { selected: boolean }): string =>
     classNames(


### PR DESCRIPTION
this is like halfway done? things that are sus rn:
- when exactly can we create/enqueue?
  - TODO actually refetch rounds on c/e success :)
  - TODO better error messages when things fail
  - active round is... the earliest round that is "in progress"
  - we can rerun the round once all matches are completed only if the next round isnt in progress. this should rerun all the matches using match "requeue" functionality (need a new api request on tournament round which forcibly requeues all its matches)
  - you can only start a round once the previous round's matches are all successful/completed
  - 
- when can we release? what exactly does releasing do?
  - we dont release until the next day (until stream)
  - as the rounds are shown we release them
  - rounds can be released once all their matches are succesful (unimportant feature)
- what does releasestatusenum mean?
  - 
- how to link to challonge?
  - tourney has two ids, use challonge.com/"external private id"
- why aren't maps showing up in the tournament round?
  - TODO lowell debug
- do we actually need more than 10 round tabs to show (if so, add pagination element lol)
  - well see, probs add paging
- link to tournament viewer: link at client link ie "http://localhost:3000/?tournamentSource=https://api.battlecode.org/api/compete/bc25java/match/tournament/?external_id_private=private_bc25javasprint1_e746726c_dd4c_4c78_9fc8_1655c87ae2d4&format=json"