### PR TITLE
emergency hide match results

### DIFF
--- a/backend/siarnaq/api/compete/serializers.py
+++ b/backend/siarnaq/api/compete/serializers.py
@@ -272,6 +272,20 @@ class MatchSerializer(serializers.ModelSerializer):
             # Staff can see everything
             pass
         elif (
+            (
+                instance.tournament_round is not None
+                and instance.tournament_round.release_status <= ReleaseStatus.HIDDEN
+            )
+            or (
+                instance.tournament_round is not None
+                and not instance.tournament_round.tournament.is_public
+            )
+            or instance.participants.filter(team__status=TeamStatus.INVISIBLE).exists()
+        ):
+            # Fully redact matches from private tournaments, unreleased tournament
+            # rounds, and those with invisible teams.
+            data["participants"] = data["replay_url"] = data["maps"] = None
+        elif (
             instance.tournament_round is not None
             and instance.tournament_round.release_status <= ReleaseStatus.PARTICIPANTS
         ):


### PR DESCRIPTION
- hide result info for unreleased tournament matches

doing it this way for now bc my staging is sooooo broken and i want to fix this asap