### PR TITLE
Fixes for Tourney Admin

### DIFF
--- a/backend/siarnaq/api/compete/serializers.py
+++ b/backend/siarnaq/api/compete/serializers.py
@@ -272,20 +272,6 @@ class MatchSerializer(serializers.ModelSerializer):
             # Staff can see everything
             pass
         elif (
-            (
-                instance.tournament_round is not None
-                and instance.tournament_round.release_status <= ReleaseStatus.HIDDEN
-            )
-            or (
-                instance.tournament_round is not None
-                and not instance.tournament_round.tournament.is_public
-            )
-            or instance.participants.filter(team__status=TeamStatus.INVISIBLE).exists()
-        ):
-            # Fully redact matches from private tournaments, unreleased tournament
-            # rounds, and those with invisible teams.
-            data["participants"] = data["replay_url"] = data["maps"] = None
-        elif (
             instance.tournament_round is not None
             and instance.tournament_round.release_status <= ReleaseStatus.PARTICIPANTS
         ):

--- a/backend/siarnaq/api/compete/serializers.py
+++ b/backend/siarnaq/api/compete/serializers.py
@@ -272,6 +272,23 @@ class MatchSerializer(serializers.ModelSerializer):
             # Staff can see everything
             pass
         elif (
+            (
+                instance.tournament_round is not None
+                and instance.tournament_round.release_status <= ReleaseStatus.HIDDEN
+            )
+            or (
+                instance.tournament_round is not None
+                and not instance.tournament_round.tournament.is_public
+            )
+            or instance.participants.filter(team__status=TeamStatus.INVISIBLE).exists()
+        ):
+            # TODO: Not sure why removing this doesn't work(shows hidden matches)
+            #  but need to ship the PR
+
+            # Fully redact matches from private tournaments, unreleased tournament
+            # rounds, and those with invisible teams.
+            data["participants"] = data["replay_url"] = data["maps"] = None
+        elif (
             instance.tournament_round is not None
             and instance.tournament_round.release_status <= ReleaseStatus.PARTICIPANTS
         ):

--- a/backend/siarnaq/api/compete/test_views.py
+++ b/backend/siarnaq/api/compete/test_views.py
@@ -408,7 +408,7 @@ class MatchSerializerTestCase(TestCase):
                     "tournament": self.r_hidden.tournament.pk,
                     "external_id": self.r_hidden.external_id,
                     "name": self.r_hidden.name,
-                    "maps": None,
+                    "maps": [self.map.pk],
                     "release_status": self.r_hidden.release_status,
                     "display_order": self.r_hidden.display_order,
                     "in_progress": self.r_hidden.in_progress,

--- a/backend/siarnaq/api/episodes/admin.py
+++ b/backend/siarnaq/api/episodes/admin.py
@@ -187,12 +187,20 @@ class TournamentAdmin(admin.ModelAdmin):
         "display_date",
         "submission_freeze",
         "is_public",
+        "private_challonge_link",
     )
     list_filter = ("episode",)
     list_select_related = ("episode",)
     ordering = ("-episode__game_release", "-submission_freeze")
     search_fields = ("name_short", "name_long")
     search_help_text = "Search for a full or abbreviated name."
+
+    def private_challonge_link(self, obj):
+        """Generate a link to the private Challonge bracket."""
+        link = f"https://challonge.com/{obj.external_id_private}"
+        return format_html(
+            '<a href="{}" target="_blank">Private Challonge Link</a>', link
+        )
 
 
 class MatchInline(admin.TabularInline):

--- a/backend/siarnaq/api/episodes/serializers.py
+++ b/backend/siarnaq/api/episodes/serializers.py
@@ -106,6 +106,10 @@ class TournamentRoundSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         data = super().to_representation(instance)
+        user = self.context["request"].user
+        # If user is staff, do not redact anything
+        if user.is_staff:
+            return data
         # Redact maps if not yet fully released
         if instance.release_status != ReleaseStatus.RESULTS:
             data["maps"] = None

--- a/backend/siarnaq/api/episodes/serializers.py
+++ b/backend/siarnaq/api/episodes/serializers.py
@@ -106,9 +106,8 @@ class TournamentRoundSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         data = super().to_representation(instance)
-        user = self.context["request"].user
         # If user is staff, do not redact anything
-        if user.is_staff:
+        if self.context["user_is_staff"]:
             return data
         # Redact maps if not yet fully released
         if instance.release_status != ReleaseStatus.RESULTS:

--- a/frontend/src/views/AdminTournament.tsx
+++ b/frontend/src/views/AdminTournament.tsx
@@ -223,7 +223,7 @@ const AdminTournament: React.FC = () => {
       >
         {tournament.isSuccess && episode.isSuccess && (
           <div className="grid max-w-96 grid-cols-2 items-center justify-start text-gray-700">
-            <span className="font-semibold">Challonge:</span>
+            <span className="font-semibold">Public Challonge:</span>
             <Button
               label="Go!"
               fullWidth={false}
@@ -406,16 +406,22 @@ const RoundPanel: React.FC<RoundPanelProps> = ({
     },
     queryClient,
   );
-  const requeue = useRequeueTournamentRound({
-    episodeId,
-    tournament: round.tournament,
-    id: round.id.toString(),
-  });
-  const release = useReleaseTournamentRound({
-    episodeId,
-    tournament: round.tournament,
-    id: round.id.toString(),
-  });
+  const requeue = useRequeueTournamentRound(
+    {
+      episodeId,
+      tournament: round.tournament,
+      id: round.id.toString(),
+    },
+    queryClient,
+  );
+  const release = useReleaseTournamentRound(
+    {
+      episodeId,
+      tournament: round.tournament,
+      id: round.id.toString(),
+    },
+    queryClient,
+  );
 
   /**
    * Can create/enqueue when:
@@ -473,7 +479,7 @@ const RoundPanel: React.FC<RoundPanelProps> = ({
           <span className="font-semibold">Maps:</span>
           <span>
             {round.maps
-              ?.map((m) => maps.data?.[m]?.name)
+              ?.map((m) => maps.data?.find((map) => map.id === m)?.name)
               .filter(isPresent)
               .join(", ") ?? "N/A"}
           </span>


### PR DESCRIPTION
- altogether hides tournament matches for unreleased rounds, unless the user is staff or the matches are requested with external id private
- adds link to django admin for private challonge bracket :)
- fixes tournament match maps ordering with a lovely hack fix :sob: 
- dont hide round maps if the user is staff
- better error display in frontend when things go wrong (but not for initialize bc that is an asynchronous task)
- actually list maps in admin page