### PR TITLE
adding separate build triggers for staging

### DIFF
--- a/deploy/galaxy/main.tf
+++ b/deploy/galaxy/main.tf
@@ -84,7 +84,7 @@ resource "google_cloudbuild_trigger" "frontend" {
     name  = "galaxy"
 
     push {
-      tag = "^siarnaq-frontend-.*"
+      tag = var.frontend_trigger_tag_pattern
     }
   }
 
@@ -156,6 +156,8 @@ module "siarnaq" {
   storage_public_name = google_storage_bucket.public.name
   storage_secure_name = google_storage_bucket.secure.name
   storage_ephemeral_name = google_storage_bucket.ephemeral.name
+
+  trigger_tag_pattern = var.siarnaq_trigger_tag_pattern
 }
 
 module "titan" {

--- a/deploy/galaxy/variables.tf
+++ b/deploy/galaxy/variables.tf
@@ -107,3 +107,13 @@ variable "saturn_secrets" {
   description = "Secrets to inject into the Saturn secret manager"
   type        = map
 }
+
+variable "siarnaq_trigger_tag_pattern" {
+  description = "Regex pattern for git tags that trigger Siarnaq backend builds"
+  type        = string
+}
+
+variable "frontend_trigger_tag_pattern" {
+  description = "Regex pattern for git tags that trigger frontend builds"
+  type        = string
+}

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -55,6 +55,9 @@ module "production" {
   saturn_secrets        = var.saturn_secrets_production
   storage_releases_name = module.releases.storage_bucket_name
 
+  siarnaq_trigger_tag_pattern  = "^siarnaq-backend-.*"
+  frontend_trigger_tag_pattern = "^siarnaq-frontend-.*"
+
   depends_on = [null_resource.apis]
 }
 
@@ -87,6 +90,9 @@ module "staging" {
   max_execute_instances = 1
   saturn_secrets        = var.saturn_secrets_staging
   storage_releases_name = module.releases.storage_bucket_name
+
+  siarnaq_trigger_tag_pattern  = "^staging-siarnaq-.*"
+  frontend_trigger_tag_pattern = "^staging-frontend-.*"
 
   depends_on = [null_resource.apis]
 }

--- a/deploy/siarnaq/main.tf
+++ b/deploy/siarnaq/main.tf
@@ -270,7 +270,7 @@ resource "google_cloudbuild_trigger" "this" {
     name  = "galaxy"
 
     push {
-      tag = "^siarnaq-backend-.*"
+      tag = var.trigger_tag_pattern
     }
   }
 

--- a/deploy/siarnaq/variables.tf
+++ b/deploy/siarnaq/variables.tf
@@ -77,3 +77,8 @@ variable "additional_secrets" {
   description = "Additional secrets to inject into the secret manager"
   type        = map
 }
+
+variable "trigger_tag_pattern" {
+  description = "Regex pattern for git tags that trigger builds"
+  type        = string
+}


### PR DESCRIPTION
This PR fixes this issue:
Currently cloud build has the same release tag regex that triggers build for both staging and production, 
We usually change it manually from cloud build to accept ^staging-siarnaq-* and ^staging-frontend-* to only deploy to staging when we want to test. 
